### PR TITLE
bugfix: Unexpected token u in JSON when following README setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ Make sure you're using Node >= 12: `nvm install 12 && nvm alias default node`
 1. `yarn`
 2. `cp .env.example .env`
 3. `cp examples/soxbase-api/.env.example examples/soxbase-api/.env`
-4. Fill in `GRAPHCMS_BEARER` in `examples/soxbase-api/.env`, in 1Pass under
+4. `cp examples/soxbase/.env.example examples/soxbase/.env`
+5. Fill in `GRAPHCMS_BEARER` in `examples/soxbase-api/.env`, in 1Pass under
    `soxbase-api`
-5. `cp examples/soxbase/.env.example examples/soxbase/.env`
+6. `cp examples/soxbase/.env.example examples/soxbase/.env`
 
 ## Customize endpoint:
 


### PR DESCRIPTION
The soxbase example workspace is included. But when following the
readme, the soxbase example .env file is not created. Resulting in
the below error.

2|soxbase         | $ next
2|soxbase         | ready - started server on 0.0.0.0:3000, url: http://localhost:3000
2|soxbase         | SyntaxError: Unexpected token u in JSON at position 0
2|soxbase         |     at JSON.parse (<anonymous>)
2|soxbase         |     at Object.<anonymous> (/Users/timhofman/Reach/sites/m2-pwa/examples/soxbase/next.config.js:47:31)
2|soxbase         |     at Module._compile (internal/modules/cjs/loader.js:1063:30)
2|soxbase         |     at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
2|soxbase         |     at Module.load (internal/modules/cjs/loader.js:928:32)
2|soxbase         |     at Function.Module._load (internal/modules/cjs/loader.js:769:14)
2|soxbase         |     at Module.require (internal/modules/cjs/loader.js:952:19)
2|soxbase         |     at require (internal/modules/cjs/helpers.js:88:18)
2|soxbase         |     at loadConfig (/Users/timhofman/Reach/sites/m2-pwa/node_modules/next/dist/next-server/server/config.js:8:72)
2|soxbase         |     at async NextServer.loadConfig (/Users/timhofman/Reach/sites/m2-pwa/node_modules/next/dist/server/next.js:1:3155)
2|soxbase         | error Command failed with exit code 1.