### PR TITLE
chore: fix duplicate in example store/locale mapping

### DIFF
--- a/examples/soxbase/.env.example
+++ b/examples/soxbase/.env.example
@@ -1,4 +1,4 @@
 NEXT_PUBLIC_GRAPHQL_ENDPOINT="http://localhost:3001/api/graphql"
 IMAGE_DOMAINS="master-7rqtwti-mfwmkrjfqvbjk.us-4.magentosite.cloud,jnz3dtiuj77ca.dummycachetest.com,backend.reachdigital.dev,media.graphcms.com"
-NEXT_PUBLIC_LOCALE_STORES='{"nl": "nl_NL", "fr-be": "fr_BE", "en": "en_GB", "nl-be": "nl_BE", "en": "en_EU"}'
+NEXT_PUBLIC_LOCALE_STORES='{"nl": "nl_NL", "fr-be": "fr_BE", "en-gb": "en_GB", "nl-be": "nl_BE", "en": "en_EU"}'
 NEXT_PUBLIC_SITE_URL="https://graphcommerce.vercel.app"


### PR DESCRIPTION
Volgens mij is dit de reden dat switchen naar de UK store niet lijkt te werken. Heb dit tevens aangepast in `NEXT_PUBLIC_LOCALE_STORES` env var in Vercel