### PR TITLE
fix(configurable-product-add-to-cart): don't show success message whe…

### DIFF
--- a/packages/magento-product-configurable/ConfigurableProductAddToCart/ConfigurableProductAddToCart.tsx
+++ b/packages/magento-product-configurable/ConfigurableProductAddToCart/ConfigurableProductAddToCart.tsx
@@ -139,7 +139,7 @@ export default function ConfigurableProductAddToCart(props: ConfigurableProductA
       </AnimatePresence>
 
       <MessageSnackbar
-        open={formState.isSubmitSuccessful && !error?.message}
+        open={!formState.isSubmitting && formState.isSubmitSuccessful && !error?.message && !data?.addProductsToCart?.user_errors?.length}
         variant='pill'
         color='default'
         action={


### PR DESCRIPTION
…n add to cart fails

due to, for example, selected qty not in stock

https://d.pr/i/wAxD18