### PR TITLE
fix: persitence layer not being purged after logout

### DIFF
--- a/.changeset/real-mangos-call.md
+++ b/.changeset/real-mangos-call.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/magento-customer': patch
+---
+
+persistence layer not purged at logout

--- a/packages/magento-customer/components/SignOutForm/SignOutForm.tsx
+++ b/packages/magento-customer/components/SignOutForm/SignOutForm.tsx
@@ -3,16 +3,20 @@ import { useRouter } from 'next/router'
 import React from 'react'
 import { ApolloCustomerErrorAlert } from '../ApolloCustomerError/ApolloCustomerErrorAlert'
 import { SignOutFormDocument } from './SignOutForm.gql'
+import { useApolloClient } from '@graphcommerce/graphql'
 
 type SignOutFormProps = { button: (props: { formState: FormState<unknown> }) => React.ReactNode }
 
 export function SignOutForm(props: SignOutFormProps) {
   const { button } = props
   const router = useRouter()
+  const client = useApolloClient()
+
   const { handleSubmit, formState, error } = useFormGqlMutation(
     SignOutFormDocument,
     {
       onComplete: () => {
+        client.clearStore()
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         router.push('/')
       },

--- a/packages/magento-customer/typePolicies.ts
+++ b/packages/magento-customer/typePolicies.ts
@@ -1,14 +1,12 @@
-import { FieldPolicy , CustomerToken, MigrateCache, Mutation, TypedTypePolicies } from '@graphcommerce/graphql'
+import {
+  FieldPolicy,
+  CustomerToken,
+  MigrateCache,
+  Mutation,
+  TypedTypePolicies,
+} from '@graphcommerce/graphql'
 import { CustomerTokenDocument } from './hooks/CustomerToken.gql'
 import { IsEmailAvailableDocument } from './hooks/IsEmailAvailable.gql'
-
-const revokeCustomerToken: FieldPolicy<Mutation['revokeCustomerToken']> = {
-  merge(_existing, incoming, options) {
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    options.cache.reset()
-    return incoming
-  },
-}
 
 const TOKEN_EXPIRATION_MS = 60 * 60 * 1000
 
@@ -74,7 +72,7 @@ const createCustomer: FieldPolicy<Mutation['createCustomer']> = {
 
 export const customerTypePolicies: TypedTypePolicies = {
   // Query: { fields: { customer } },
-  Mutation: { fields: { generateCustomerToken, revokeCustomerToken, createCustomer } },
+  Mutation: { fields: { generateCustomerToken, createCustomer } },
   CustomerToken: { fields: { valid } },
 }
 


### PR DESCRIPTION
The first none cached query eventually triggered the purge
All pages between logout and that first query were displaying an incorrect user state