### PR TITLE
fix: prevent sx prop from being passed to form element

### DIFF
--- a/.changeset/tiny-jokes-wonder.md
+++ b/.changeset/tiny-jokes-wonder.md
@@ -1,0 +1,5 @@
+---
+"@graphcommerce/next-ui": patch
+---
+
+Prevent sx prop from being passed to form element

--- a/packages/next-ui/Form/Form.tsx
+++ b/packages/next-ui/Form/Form.tsx
@@ -31,9 +31,9 @@ const styles = ({ theme, contained = false, background }: { theme: Theme } & For
   ])
 
 export const Form = styled('form', {
-  shouldForwardProp: (prop) => prop !== 'contained',
+  shouldForwardProp: (prop) => prop !== 'contained' && prop !== 'sx',
 })<FormStyleProps>(styles)
 
 export const FormDiv = styled('div', {
-  shouldForwardProp: (prop) => prop !== 'contained',
+  shouldForwardProp: (prop) => prop !== 'contained' && prop !== 'sx',
 })<FormStyleProps>(styles)


### PR DESCRIPTION
Prevents ```Invalid value for prop `sx` on <form> tag.``` error