### PR TITLE
fix: if recent order images > 1, images now actually show

### DIFF
--- a/.changeset/lazy-onions-join.md
+++ b/.changeset/lazy-onions-join.md
@@ -1,0 +1,6 @@
+---
+"@graphcommerce/magento-customer-order": patch
+"@graphcommerce/magento-customer": patch
+---
+
+fix: if recent order images > 1, images now actually show

--- a/packages/magento-customer-order/components/OrderCard/OrderCard.tsx
+++ b/packages/magento-customer-order/components/OrderCard/OrderCard.tsx
@@ -120,19 +120,17 @@ export function OrderCard(props: OrderCardProps) {
               }}
             />
           </OrderRow>
-          <Box
-            className={classes.orderProducts}
-            sx={{ display: 'flex', justifyContent: 'center', flexWrap: 'wrap' }}
-          >
+          <Box className={classes.orderProducts}>
             <Box
               className={classes.images}
               sx={(theme) => ({
                 display: 'grid',
                 gridAutoFlow: 'column',
                 gap: theme.spacings.xxs,
+                gridTemplateColumns: 'repeat(auto-fit, 88px)',
+                placeContent: 'center',
+                placeItems: 'center',
                 padding: theme.spacings.xxs,
-                width: responsiveVal(75, 125),
-                height: responsiveVal(75, 125),
               })}
             >
               {items


### PR DESCRIPTION

![joe](https://user-images.githubusercontent.com/31548701/163203048-5ab5dc3e-66ce-49da-8bc6-c290776c79b6.png)


Die 88px komt uit packages/magento-customer-order/components/OrderCardItemImage/OrderCardItemImage.tsx:24