### PR TITLE
fix: __typename is mandatory as wishlistchip prop value

### DIFF
--- a/.changeset/stale-dryers-shake.md
+++ b/.changeset/stale-dryers-shake.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/magento-wishlist': patch
+---
+
+remove mandatory \_\_typename from chip base props

--- a/packages/magento-wishlist/components/ProductWishlistChip/ProductWishlistChip.graphql
+++ b/packages/magento-wishlist/components/ProductWishlistChip/ProductWishlistChip.graphql
@@ -1,4 +1,3 @@
 fragment ProductWishlistChip on ProductInterface {
-  __typename
   sku
 }


### PR DESCRIPTION
This is old code from before the split into a chip base and multiple composition layers
It is now in the way when data is passed in without a typename