### PR TITLE
Bug/actioncard hidden when value doesnt exist

### DIFF
--- a/.changeset/gentle-windows-lie.md
+++ b/.changeset/gentle-windows-lie.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/next-ui': minor
+---
+
+Previously when the persisted selected value didn't exist in the list of ActionCard items, all items would be hidden. In this fix we set the hidden prop in the ActionCardList component, where we check if the value exists, if not, we display all items

--- a/packages/next-ui/ActionCard/ActionCardList.tsx
+++ b/packages/next-ui/ActionCard/ActionCardList.tsx
@@ -67,7 +67,7 @@ export const ActionCardList = React.forwardRef<HTMLDivElement, ActionCardListPro
         }
 
     type ActionCardLike = React.ReactElement<
-      Pick<ActionCardProps, 'value' | 'selected' | 'disabled' | 'onClick'>
+      Pick<ActionCardProps, 'value' | 'selected' | 'disabled' | 'onClick' | 'hidden'>
     >
     function isActionCardLike(el: React.ReactElement): el is ActionCardLike {
       const hasValue = (el as ActionCardLike).props.value
@@ -132,6 +132,7 @@ export const ActionCardList = React.forwardRef<HTMLDivElement, ActionCardListPro
         {childReactNodes.map((child) =>
           React.cloneElement(child, {
             onClick: handleChange,
+            hidden: !!value && value !== child.props.value,
             selected:
               child.props.selected === undefined
                 ? isValueSelected(child.props.value, value)

--- a/packages/next-ui/ActionCard/ActionCardListForm.tsx
+++ b/packages/next-ui/ActionCard/ActionCardListForm.tsx
@@ -34,7 +34,7 @@ export function ActionCardListForm<T extends ActionCardItemBase>(
       control={control}
       name={name}
       rules={{ required, ...rules, validate: (v) => (v ? true : errorMessage) }}
-      render={({ field: { onChange, value, onBlur, ref }, fieldState, formState }) => (
+      render={({ field: { onChange, value, ref }, fieldState, formState }) => (
         <ActionCardList
           required
           value={value}
@@ -49,7 +49,6 @@ export function ActionCardListForm<T extends ActionCardItemBase>(
               key={item.value}
               value={item.value}
               selected={value === item.value}
-              hidden={!!value && value !== item.value}
               onReset={(e) => {
                 e.preventDefault()
                 onChange(null)


### PR DESCRIPTION
Previously when the persisted selected value didn't exist in the list of ActionCard items, all items would be hidden. In this fix we set the hidden prop in the ActionCardList component, where we check if the value exists, if not, we display all items