### PR TITLE
add media query guard to category menu behaviour.

### DIFF
--- a/.changeset/funny-ligers-laugh.md
+++ b/.changeset/funny-ligers-laugh.md
@@ -1,0 +1,5 @@
+---
+"@graphcommerce/next-ui": patch
+---
+
+add media query guard to category menu behaviour.

--- a/packages/next-ui/Navigation/components/NavigationItem.tsx
+++ b/packages/next-ui/Navigation/components/NavigationItem.tsx
@@ -114,7 +114,7 @@ export const NavigationItem = React.memo<NavigationItemProps>((props) => {
           tabIndex={tabIndex}
           onClick={(e) => {
             e.preventDefault()
-            if (!isSelected && !animating.get()) {
+            if (!isSelected && !(matchMedia.up('md') && animating.get())) {
               selection.set(itemPath)
             }
           }}


### PR DESCRIPTION
Prevents the drill-down menu from breaking on smaller screens