### PR TITLE
New form handling

### DIFF
--- a/packages/react-hook-form/__mocks__/TestEmailCart.graphql
+++ b/packages/react-hook-form/__mocks__/TestEmailCart.graphql
@@ -1,0 +1,8 @@
+mutation TestEmailCart($cartId: String!, $email: String!) {
+  setGuestEmailOnCart(input: { cart_id: $cartId, email: $email }) {
+    cart {
+      id
+      email
+    }
+  }
+}

--- a/packages/react-hook-form/__mocks__/TestEmailCartGet.graphql
+++ b/packages/react-hook-form/__mocks__/TestEmailCartGet.graphql
@@ -1,0 +1,6 @@
+query TestEmailCartGet($cartId: String!) {
+  cart(cart_id: $cartId) {
+    id
+    email
+  }
+}

--- a/packages/react-hook-form/__tests__/useFormApollo.tsx
+++ b/packages/react-hook-form/__tests__/useFormApollo.tsx
@@ -1,0 +1,305 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { MockedProvider, MockedResponse } from '@apollo/client/testing'
+import { render, fireEvent, waitFor } from '@testing-library/react'
+import { GraphQLError } from 'graphql'
+import { useEffect, useState } from 'react'
+import { useFormState } from 'react-hook-form'
+import {
+  TestEmailCartDocument,
+  TestEmailCartMutation,
+  TestEmailCartMutationVariables,
+} from '../__mocks__/TestEmailCart.gql'
+import {
+  TestShippingAddressFormDocument,
+  TestShippingAddressFormMutation,
+  TestShippingAddressFormMutationVariables,
+} from '../__mocks__/TestShippingAddressForm.gql'
+import {
+  FormProviderApollo,
+  SubmitValidHandler,
+  useFormApollo,
+  useFormApolloContext,
+  useFormApolloData,
+  useFormApolloError,
+} from '../hooks/useFormApollo'
+import { useQuery } from '@apollo/client'
+
+import '@testing-library/jest-dom'
+import {
+  TestEmailCartGetDocument,
+  TestEmailCartGetQueryVariables,
+} from '../__mocks__/TestEmailCartGet.gql'
+
+const FormState = () => {
+  const { isSubmitted, isSubmitting, isSubmitSuccessful, isDirty } =
+    useFormState<TestShippingAddressFormMutationVariables>()
+
+  return (
+    <>
+      <div data-testid='isSubmitted'>{isSubmitted ? '1' : ''}</div>
+      <div data-testid='isSubmitting'>{isSubmitting ? '1' : ''}</div>
+      <div data-testid='isSubmitSuccessful'>{isSubmitSuccessful ? '1' : ''}</div>
+      {isSubmitted ? <div data-testid='submitted' /> : <div data-testid='notSubmitted' />}
+      {isSubmitting ? <div data-testid='submitting' /> : <div data-testid='notSubmitting' />}
+      {isSubmitSuccessful ? <div data-testid='successful' /> : <div data-testid='notSuccessful' />}
+      {isDirty ? <div data-testid='dirty' /> : <div data-testid='notDirty' />}
+    </>
+  )
+}
+
+const FormResult = () => {
+  const data = useFormApolloData<TestShippingAddressFormMutation>()
+  const error = useFormApolloError()
+
+  return (
+    <>
+      <div data-testid='result'>{JSON.stringify(data)}</div>
+      <div data-testid='networkError'>{error?.networkError?.message}</div>
+      <div data-testid='graphQLErrors'>{error?.graphQLErrors[0]?.message}</div>
+    </>
+  )
+}
+
+let count = 0
+
+type FormProps = {
+  onValid?: SubmitValidHandler<
+    TestShippingAddressFormMutation,
+    TestShippingAddressFormMutationVariables
+  >
+}
+
+const FormShippingAddress = (props: FormProps) => {
+  const { onValid } = props
+  const [internalCount, setInternalCount] = useState(0)
+  const form = useFormApollo({ mutation: TestShippingAddressFormDocument })
+  count++
+
+  return (
+    <FormProviderApollo {...form}>
+      <form onSubmit={form.handleSubmit(onValid)}>
+        <button type='submit'>Submit</button>
+        <button
+          type='button'
+          data-testid='state'
+          onClick={() => setInternalCount(internalCount + 1)}
+        >
+          Increment
+        </button>
+        <div data-testid='rendercount'>{count}</div>
+        <FormState />
+        <FormResult />
+      </form>
+    </FormProviderApollo>
+  )
+}
+
+describe('useFormApollo', () => {
+  it('it doesnt rerender and is able to submit successfully', async () => {
+    const TestShippingAddressFormMock: MockedResponse<TestShippingAddressFormMutation> = {
+      request: {
+        query: TestShippingAddressFormDocument,
+        variables: { customerNote: 'joi' },
+      },
+      result: { data: { setShippingAddressesOnCart: { cart: { id: '123' } } } },
+    }
+
+    count = 0
+    const { findByTestId, getByTestId, findByText } = render(
+      <MockedProvider mocks={[TestShippingAddressFormMock]} addTypename={false}>
+        <FormShippingAddress />
+      </MockedProvider>,
+    )
+
+    // Default State
+    expect((await findByTestId('result')).innerHTML).toBeFalsy()
+    expect((await findByTestId('isSubmitted')).innerHTML).toBeFalsy()
+    expect((await findByTestId('isSubmitting')).innerHTML).toBeFalsy()
+    expect((await findByTestId('isSubmitSuccessful')).innerHTML).toBeFalsy()
+
+    fireEvent.click(await findByText('Submit'))
+
+    expect((await findByTestId('rendercount')).innerHTML).toBe('1')
+
+    fireEvent.click(await findByTestId('state'))
+    expect((await findByTestId('rendercount')).innerHTML).toBe('2')
+
+    expect((await findByTestId('result')).innerHTML).toBeFalsy()
+    expect((await findByTestId('isSubmitted')).innerHTML).toBeFalsy()
+    expect((await findByTestId('isSubmitting')).innerHTML).toBeTruthy()
+    expect((await findByTestId('isSubmitSuccessful')).innerHTML).toBeFalsy()
+
+    await waitFor(() => expect(getByTestId('successful')).toBeTruthy())
+
+    expect((await findByTestId('isSubmitted')).innerHTML).toBeTruthy()
+    expect((await findByTestId('isSubmitting')).innerHTML).toBeFalsy()
+    expect((await findByTestId('isSubmitSuccessful')).innerHTML).toBeTruthy()
+    expect((await findByTestId('rendercount')).innerHTML).toBe('2')
+
+    expect((await findByTestId('result')).innerHTML).toMatchInlineSnapshot(
+      `"{"setShippingAddressesOnCart":{"cart":{"id":"123"}}}"`,
+    )
+    expect((await findByTestId('networkError')).innerHTML).toBeFalsy()
+    expect((await findByTestId('graphQLErrors')).innerHTML).toBeFalsy()
+    expect((await findByTestId('rendercount')).innerHTML).toBe('2')
+  })
+
+  it(`networkError occured and isSubmitSuccessful is false`, async () => {
+    const TestShippingAddressFormMock: MockedResponse<TestShippingAddressFormMutation> = {
+      request: {
+        query: TestShippingAddressFormDocument,
+        variables: { customerNote: 'joi' },
+      },
+      error: new Error('Network Error'),
+    }
+
+    count = 0
+    const { findByTestId, getByTestId, findByText } = render(
+      <MockedProvider mocks={[TestShippingAddressFormMock]} addTypename={false}>
+        <FormShippingAddress />
+      </MockedProvider>,
+    )
+
+    fireEvent.click(await findByText('Submit'))
+    expect((await findByTestId('isSubmitting')).innerHTML).toBeTruthy()
+
+    await waitFor(() => expect(getByTestId('notSubmitting')).toBeTruthy())
+
+    expect((await findByTestId('isSubmitSuccessful')).innerHTML).toBeFalsy()
+    expect((await findByTestId('result')).innerHTML).toBeFalsy()
+    expect((await findByTestId('networkError')).innerHTML).toBe('Network Error')
+    expect((await findByTestId('graphQLErrors')).innerHTML).toBeFalsy()
+    expect((await findByTestId('rendercount')).innerHTML).toBe('1')
+  })
+
+  it(`graphqlErrors occured and isSubmitSuccessful is false`, async () => {
+    const TestShippingAddressFormMock: MockedResponse<TestShippingAddressFormMutation> = {
+      request: {
+        query: TestShippingAddressFormDocument,
+        variables: { customerNote: 'joi' },
+      },
+      result: { errors: [new GraphQLError('GraphQL Error')] },
+    }
+
+    count = 0
+    const { findByTestId, getByTestId, findByText } = render(
+      <MockedProvider mocks={[TestShippingAddressFormMock]} addTypename={false}>
+        <FormShippingAddress />
+      </MockedProvider>,
+    )
+
+    fireEvent.click(await findByText('Submit'))
+    expect((await findByTestId('isSubmitting')).innerHTML).toBeTruthy()
+
+    await waitFor(() => expect(getByTestId('notSubmitting')).toBeTruthy())
+
+    expect((await findByTestId('isSubmitSuccessful')).innerHTML).toBeFalsy()
+    expect((await findByTestId('result')).innerHTML).toBeFalsy()
+    expect((await findByTestId('networkError')).innerHTML).toBeFalsy()
+    expect((await findByTestId('graphQLErrors')).innerHTML).toBe('GraphQL Error')
+    expect((await findByTestId('rendercount')).innerHTML).toBe('1')
+  })
+
+  it('should be possible to modify the variables', async () => {
+    const TestShippingAddressFormMock = {
+      request: {
+        query: TestShippingAddressFormDocument,
+        variables: { customerNote: 'joi2' },
+      },
+      result: { data: { setShippingAddressesOnCart: { cart: { id: '123' } } } },
+    }
+
+    count = 0
+    let result: TestShippingAddressFormMutation | undefined
+    const { findByTestId, getByTestId, findByText } = render(
+      <MockedProvider mocks={[TestShippingAddressFormMock]} addTypename={false}>
+        <FormShippingAddress
+          onValid={async (exec, variables) => {
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+            result = (await exec({
+              ...variables,
+              customerNote: 'joi2',
+            })) as TestShippingAddressFormMutation
+          }}
+        />
+      </MockedProvider>,
+    )
+
+    fireEvent.click(await findByText('Submit'))
+    expect((await findByTestId('isSubmitting')).innerHTML).toBeTruthy()
+    await waitFor(() => expect(getByTestId('notSubmitting')).toBeTruthy())
+
+    expect((await findByTestId('isSubmitSuccessful')).innerHTML).toBeTruthy()
+    expect((await findByTestId('result')).innerHTML).toMatchInlineSnapshot(
+      `"{"setShippingAddressesOnCart":{"cart":{"id":"123"}}}"`,
+    )
+    expect((await findByTestId('networkError')).innerHTML).toBeFalsy()
+    expect((await findByTestId('graphQLErrors')).innerHTML).toBeFalsy()
+    expect((await findByTestId('rendercount')).innerHTML).toBe('1')
+    expect(result).toMatchObject(TestShippingAddressFormMock.result.data)
+  })
+
+  function FormSyncWithQuery() {
+    const { reset } = useFormApolloContext<TestEmailCartMutation, TestEmailCartMutationVariables>()
+    const { data } = useQuery(TestEmailCartGetDocument, { variables: { cartId: '123' } })
+    const cartId = data?.cart?.id
+    const email = data?.cart?.email ?? undefined
+    useEffect(() => reset({ cartId, email }), [cartId, email, reset])
+    return null
+  }
+
+  const FormEmailCart = () => {
+    const form = useFormApollo(
+      { mutation: TestEmailCartDocument },
+      { defaultValues: { cartId: '123' } },
+    )
+
+    return (
+      <FormProviderApollo {...form}>
+        <form onSubmit={form.handleSubmit()}>
+          <button type='submit'>Submit</button>
+          <input type='text' data-testid='email' {...form.register('email')} />
+          <div data-testid='rendercount'>{count}</div>
+          <FormState />
+          <FormResult />
+          {/* <FormSyncWithQuery /> */}
+        </form>
+      </FormProviderApollo>
+    )
+  }
+
+  it('resets the form when the results come in', async () => {
+    const TestEmailCartMock: MockedResponse<TestEmailCartMutation> = {
+      request: {
+        query: TestEmailCartDocument,
+        variables: { cartId: '123', email: 'paul@reachdigital.nl' },
+      },
+      result: {
+        data: { setGuestEmailOnCart: { cart: { id: '123', email: 'paul@reachdigital.nl' } } },
+      },
+    }
+
+    const { findByTestId, getByTestId, findByText } = render(
+      <MockedProvider mocks={[TestEmailCartMock]} addTypename={false}>
+        <FormEmailCart />
+      </MockedProvider>,
+    )
+
+    fireEvent.change(getByTestId('email'), { target: { value: 'paul@reachdigital.nl' } })
+
+    expect(await findByTestId('dirty')).toBeInTheDocument()
+
+    fireEvent.click(await findByText('Submit'))
+    expect((await findByTestId('isSubmitting')).innerHTML).toBeTruthy()
+    await waitFor(() => expect(getByTestId('notSubmitting')).toBeTruthy())
+
+    expect((await findByTestId('networkError')).innerHTML).toBeFalsy()
+    expect((await findByTestId('graphQLErrors')).innerHTML).toBeFalsy()
+    expect((await findByTestId('isSubmitSuccessful')).innerHTML).toBeTruthy()
+    expect((await findByTestId('result')).innerHTML).toMatchInlineSnapshot(
+      `"{"setGuestEmailOnCart":{"cart":{"id":"123","email":"paul@reachdigital.nl"}}}"`,
+    )
+
+    expect(await findByTestId('notDirty')).toBeInTheDocument()
+  })
+})

--- a/packages/react-hook-form/hooks/useFormApollo.tsx
+++ b/packages/react-hook-form/hooks/useFormApollo.tsx
@@ -1,0 +1,168 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { ApolloError, MutationOptions, QueryOptions, useApolloClient } from '@apollo/client'
+import { useMotionValueValue } from '@graphcommerce/framer-utils'
+import { isMotionValue, MotionValue, useMotionValue } from 'framer-motion'
+import {
+  FieldValues,
+  FormProvider,
+  FormProviderProps,
+  SubmitErrorHandler,
+  useForm,
+  useFormContext,
+  UseFormProps,
+  UseFormReturn,
+} from 'react-hook-form'
+
+export type SubmitValidHandler<Q extends Record<string, unknown>, V extends FieldValues> = (
+  execute: (variables?: V) => Promise<Q>,
+  variables: V,
+) => any | Promise<any>
+
+type HandleSubmit<Q extends Record<string, unknown>, V extends FieldValues> = (
+  onValid?: SubmitValidHandler<Q, V>,
+  onInvalid?: SubmitErrorHandler<V>,
+) => (e?: React.BaseSyntheticEvent) => Promise<void>
+
+export type UseFormGqlMutationReturn<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Q extends Record<string, unknown> = Record<string, unknown>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  V extends FieldValues = FieldValues,
+> = Omit<UseFormReturn<V>, 'handleSubmit' | 'formState'> & {
+  data: MotionValue<Q | null | undefined>
+  error: MotionValue<ApolloError | null | undefined>
+  handleSubmit: HandleSubmit<Q, V>
+}
+
+function isMutation<Q, V>(
+  operation: MutationOptions<Q, V> | QueryOptions<V, Q>,
+): operation is MutationOptions<Q, V> {
+  return (operation as MutationOptions<Q, V>).mutation !== undefined
+}
+
+/**
+ * `useApolloForm`
+ *
+ * Example:
+ *
+ * Without any additional logic
+ *
+ * ```tsx
+ * const form = useFormApollo({
+ *   mutation: TestShippingAddressFormDocument,
+ * })
+ *
+ * const onSubmit = form.handleSubmit()
+ * ```
+ *
+ * With additional logic
+ *
+ * ```tsx
+ * const form = useFormApollo({
+ *   mutation: TestShippingAddressFormDocument,
+ * })
+ *
+ * const onSubmit = form.handleSubmit(async (execute, variables) => {
+ *   // Modify variables before executing
+ *   const result = await execute({ ...variables, customerNote: 'joi' })
+ *
+ *   if (!result.errors) {
+ *     // Do something with a successful operation
+ *   }
+ *
+ *   return result
+ * })
+ * ```
+ */
+export function useFormApollo<Q extends Record<string, unknown>, V extends FieldValues>(
+  operation: QueryOptions<V, Q>,
+  useFormProps?: UseFormProps<V>,
+  resetOnResult?: (result: Q) => V,
+): UseFormGqlMutationReturn<Q, V>
+export function useFormApollo<Q extends Record<string, unknown>, V extends FieldValues>(
+  operation: MutationOptions<Q, V>,
+  useFormProps?: UseFormProps<V>,
+  resetOnResult?: (result: Q) => V,
+): UseFormGqlMutationReturn<Q, V>
+export function useFormApollo<Q extends Record<string, unknown>, V extends FieldValues>(
+  operation: MutationOptions<Q, V> | QueryOptions<Partial<V>, Q>,
+  useFormProps: UseFormProps<V> = {},
+  resetOnResult?: (result: Q) => V,
+): UseFormGqlMutationReturn<Q, V> {
+  const data = useMotionValue<Q | null | undefined>(undefined)
+  const error = useMotionValue<ApolloError | null | undefined>(undefined)
+  const client = useApolloClient()
+  const form = useForm<V>(useFormProps)
+
+  const defaultHandler: SubmitValidHandler<Q, V> = (execute, variables) => execute(variables)
+
+  return {
+    ...form,
+    data,
+    error,
+    handleSubmit: (onValid = defaultHandler, onInvalid = undefined) => {
+      const caller = form.handleSubmit(
+        (formValues, event) =>
+          onValid(async (variables: V = formValues) => {
+            error.set(null)
+
+            const result = isMutation(operation)
+              ? await client.mutate({ ...operation, variables })
+              : await client.query({ ...operation, variables })
+
+            if (!result.data)
+              throw Error(
+                result.errors
+                  ? result.errors[0].message
+                  : '[useApolloForm] No data returned from Apollo operation',
+              )
+
+            data.set(result.data)
+            return result.data
+          }, formValues),
+        onInvalid,
+      )
+
+      return async (e) => {
+        try {
+          await caller(e)
+        } catch (err) {
+          data.set(undefined)
+          if (err instanceof ApolloError) error.set(err)
+          else throw err
+        }
+      }
+    },
+  }
+}
+
+export function FormProviderApollo<Q extends Record<string, unknown>, V extends FieldValues>(
+  props: UseFormGqlMutationReturn<Q, V> & { children: React.ReactNode },
+) {
+  return <FormProvider {...(props as unknown as FormProviderProps)} />
+}
+
+function isFormApollo<Q extends Record<string, unknown>, V extends FieldValues>(
+  form: UseFormGqlMutationReturn<Q, V> | UseFormReturn<V>,
+): form is UseFormGqlMutationReturn<Q, V> {
+  return isMotionValue((form as UseFormGqlMutationReturn<Q, V>).data)
+}
+
+export function useFormApolloContext<
+  Q extends Record<string, unknown>,
+  V extends FieldValues = FieldValues,
+>(): UseFormGqlMutationReturn<Q, V> {
+  const context = useFormContext()
+  if (isFormApollo(context)) {
+    return context as unknown as UseFormGqlMutationReturn<Q, V>
+  }
+  throw new Error('useFormGraphQLContext must be used within a FormProviderGraphQL')
+}
+
+export function useFormApolloData<Q extends Record<string, unknown>>(): Q | null | undefined {
+  return useMotionValueValue(useFormApolloContext<Q>().data, (res) => res)
+}
+
+export function useFormApolloError(): ApolloError | null | undefined {
+  return useMotionValueValue(useFormApolloContext().error, (err) => err)
+}

--- a/packages/react-hook-form/package.json
+++ b/packages/react-hook-form/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@apollo/client": "^3.7.2",
     "graphql": "16.6.0",
-    "react-hook-form": "7.40.0"
+    "react-hook-form": "7.41.0"
   },
   "devDependencies": {
     "@graphcommerce/eslint-config-pwa": "5.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9271,10 +9271,10 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
-react-hook-form@7.40.0:
-  version "7.40.0"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.40.0.tgz#62bc939dddca88522cd7f5135b6603192ccf7e17"
-  integrity sha512-0rokdxMPJs0k9bvFtY6dbcSydyNhnZNXCR49jgDr/aR03FDHFOK6gfh8ccqB3fl696Mk7lqh04xdm+agqWXKSw==
+react-hook-form@7.41.0:
+  version "7.41.0"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.41.0.tgz#cc0871f4784e7233ac8466300da557d622154414"
+  integrity sha512-u1cHOXujr+AsNBoeCtcCuRwPh87mXAgKtXqd3qTCBgNFYzVZLXjYgLcynORpAgqhe24r5scucR8+6gfWaXBtHQ==
 
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"


### PR DESCRIPTION
Implements a new form handling hook which reduces rererenders.

Learnings: using watch or formState causes rerenders, replace all occurences of watch with useWatch and formState with useFormState