### PR TITLE
Option to not require meta tags for categories

### DIFF
--- a/.changeset/plenty-hairs-laugh.md
+++ b/.changeset/plenty-hairs-laugh.md
@@ -1,0 +1,6 @@
+---
+"@graphcommerce/magento-category": patch
+"@graphcommerce/magento-graphcms": patch
+---
+
+Option to not require meta tags for categories

--- a/examples/magento-graphcms/.changeset/fast-pens-sing.md
+++ b/examples/magento-graphcms/.changeset/fast-pens-sing.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/magento-category': minor
+---
+
+option to not require meta tags for categories

--- a/examples/magento-graphcms/pages/[...url].tsx
+++ b/examples/magento-graphcms/pages/[...url].tsx
@@ -66,19 +66,17 @@ function CategoryPage(props: CategoryProps) {
     <>
       <CategoryMeta
         params={params}
-        title={page?.metaTitle ?? page?.title}
+        title={page?.metaTitle}
         metaDescription={page?.metaDescription}
         metaRobots={page?.metaRobots.toLowerCase().split('_') as MetaRobots[]}
         canonical={page?.url ? `/${page.url}` : undefined}
         {...category}
       />
-
       <LayoutHeader floatingMd>
         <LayoutTitle size='small' component='span'>
           {category?.name ?? page.title}
         </LayoutTitle>
       </LayoutHeader>
-
       {!isLanding && (
         <Container maxWidth={false}>
           <LayoutTitle
@@ -95,7 +93,6 @@ function CategoryPage(props: CategoryProps) {
           </LayoutTitle>
         </Container>
       )}
-
       {isCategory && isLanding && (
         <CategoryHeroNav
           {...category}
@@ -103,7 +100,6 @@ function CategoryPage(props: CategoryProps) {
           title={<CategoryHeroNavTitle>{category?.name}</CategoryHeroNavTitle>}
         />
       )}
-
       {isCategory && !isLanding && (
         <ProductListParamsProvider value={params}>
           <CategoryDescription description={category.description} />
@@ -130,7 +126,6 @@ function CategoryPage(props: CategoryProps) {
           </Container>
         </ProductListParamsProvider>
       )}
-
       {page && (
         <RowRenderer
           content={page.content}

--- a/packages/magento-category/components/CategoryMeta/CategoryMeta.tsx
+++ b/packages/magento-category/components/CategoryMeta/CategoryMeta.tsx
@@ -9,12 +9,11 @@ export type CategoryMetaProps = CategoryMetaFragment &
 
 export function CategoryMeta(props: CategoryMetaProps) {
   const { meta_title, meta_description, name, params } = props
-  let {
-    title = meta_title ?? name ?? '',
-    metaDescription = meta_description ?? undefined,
-    metaRobots,
-    canonical,
-  } = props
+  let { title = '', metaDescription = '', metaRobots, canonical } = props
+
+  if (!title && meta_title) title = meta_title
+  if (!title && name) title = name
+  if (!metaDescription && meta_description) metaDescription = meta_description
 
   if (params?.url && !canonical) canonical = `/${params.url}`
 


### PR DESCRIPTION
Option to not require meta tags for categories. 
This may be handy when you want to add something to the page in Hygraph, but still want to get the meta tags from Magento.