### PR TITLE
Fix scroll issue with bottom overlay on Android

### DIFF
--- a/.changeset/slimy-kangaroos-report.md
+++ b/.changeset/slimy-kangaroos-report.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/next-ui': patch
+---
+
+Fix scroll issue with bottom overlay on Android

--- a/packages/next-ui/Overlay/components/OverlayBase.tsx
+++ b/packages/next-ui/Overlay/components/OverlayBase.tsx
@@ -287,7 +287,7 @@ export function OverlayBase(incomingProps: LayoutOverlayBaseProps) {
                 borderTopLeftRadius: theme.shape.borderRadius * 3,
                 borderTopRightRadius: theme.shape.borderRadius * 3,
                 gridTemplate: `"beforeOverlay" "overlay"`,
-                height: dvh(100),
+                height: `calc(${dvh(100)} - 1px)`,
               },
             },
             [theme.breakpoints.up('md')]: {

--- a/packages/next-ui/Overlay/components/OverlayBase.tsx
+++ b/packages/next-ui/Overlay/components/OverlayBase.tsx
@@ -288,6 +288,17 @@ export function OverlayBase(incomingProps: LayoutOverlayBaseProps) {
                 borderTopRightRadius: theme.shape.borderRadius * 3,
                 gridTemplate: `"beforeOverlay" "overlay"`,
                 height: `calc(${dvh(100)} - 1px)`,
+
+                '&::after': {
+                  content: `""`,
+                  display: 'block',
+                  position: 'absolute',
+                  width: '100%',
+                  height: '1px',
+                  top: 'calc(100% - 1px)',
+                  left: '0',
+                  background: theme.palette.background.paper,
+                },
               },
             },
             [theme.breakpoints.up('md')]: {


### PR DESCRIPTION
This prevent scrolling Android browser UI in and out of view causing the browser to resize, which in turn causes the bottom overlay to jump around