### PR TITLE
chore: enable password fields when there is an error and user input correction is required

### DIFF
--- a/.changeset/fresh-icons-wait.md
+++ b/.changeset/fresh-icons-wait.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/magento-customer': patch
+---
+
+enable password fields when there is an error and user input correction is required.

--- a/packages/magento-customer/components/SignUpForm/SignUpFormInline.tsx
+++ b/packages/magento-customer/components/SignUpForm/SignUpFormInline.tsx
@@ -78,7 +78,7 @@ export function SignUpFormInline({
         <TextField
           variant='outlined'
           type='password'
-          error={!!formState.errors.password}
+          error={!!formState.errors.password || !!form.error}
           label={<Trans id='Password' />}
           autoFocus
           autoComplete='new-password'
@@ -96,7 +96,7 @@ export function SignUpFormInline({
         <TextField
           variant='outlined'
           type='password'
-          error={!!formState.errors.confirmPassword}
+          error={!!formState.errors.confirmPassword || !!form.error}
           label={<Trans id='Confirm password' />}
           autoComplete='new-password'
           required

--- a/packages/magento-customer/components/SignUpForm/SignUpFormInline.tsx
+++ b/packages/magento-customer/components/SignUpForm/SignUpFormInline.tsx
@@ -66,7 +66,7 @@ export function SignUpFormInline({
 
   return (
     <Form onSubmit={submitHandler} noValidate className={classes.form} sx={{ padding: 0 }}>
-      <FormRow key='inline-signup' className={classes.row} sx={{ padding: 0 }}>
+      <FormRow className={classes.row} sx={{ padding: 0 }}>
         <TextField
           variant='outlined'
           type='password'
@@ -102,7 +102,7 @@ export function SignUpFormInline({
         />
       </FormRow>
 
-      <FormRow key='signup-submit'>
+      <FormRow>
         <FormRow
           className={classes.buttonFormRow}
           sx={(theme) => ({

--- a/packages/magento-customer/components/SignUpForm/SignUpFormInline.tsx
+++ b/packages/magento-customer/components/SignUpForm/SignUpFormInline.tsx
@@ -84,7 +84,7 @@ export function SignUpFormInline({
             },
           })}
           helperText={error?.message}
-          disabled={formState.isSubmitting}
+          disabled={formState.isSubmitting && !error?.message}
         />
         <TextField
           variant='outlined'
@@ -98,7 +98,7 @@ export function SignUpFormInline({
             validate: (value) => value === watchPassword,
           })}
           helperText={!!formState.errors.confirmPassword && <Trans id='Passwords should match' />}
-          disabled={formState.isSubmitting}
+          disabled={formState.isSubmitting && !error?.message}
         />
       </FormRow>
 
@@ -117,7 +117,7 @@ export function SignUpFormInline({
             <Button
               fullWidth
               type='submit'
-              loading={formState.isSubmitting}
+              loading={formState.isSubmitting && !error?.message}
               color='secondary'
               variant='pill'
             >

--- a/packages/magento-customer/components/SignUpForm/SignUpFormInline.tsx
+++ b/packages/magento-customer/components/SignUpForm/SignUpFormInline.tsx
@@ -1,3 +1,4 @@
+import { ApolloErrorAlert } from '@graphcommerce/ecommerce-ui'
 import { useQuery } from '@graphcommerce/graphql'
 import { StoreConfigDocument } from '@graphcommerce/magento-store'
 import { Button, extendableComponent, Form, FormRow } from '@graphcommerce/next-ui'
@@ -37,19 +38,26 @@ export function SignUpFormInline({
   const form = useFormGqlMutation<
     SignUpMutation,
     SignUpMutationVariables & { confirmPassword?: string }
-  >(Mutation, {
-    // todo(paales): This causes dirty data to be send to the backend.
-    defaultValues: {
-      email,
-      prefix: '-',
-      firstname: firstname ?? '-',
-      lastname: lastname ?? '-',
+  >(
+    Mutation,
+    {
+      // todo(paales): This causes dirty data to be send to the backend.
+      defaultValues: {
+        email,
+        prefix: '-',
+        firstname: firstname ?? '-',
+        lastname: lastname ?? '-',
+      },
+      onBeforeSubmit: (values) => ({ ...values, email }),
+      onComplete: (result) => {
+        if (!result.errors) onSubmitted()
+      },
     },
-    onBeforeSubmit: (values) => ({ ...values, email }),
-  })
+    { errorPolicy: 'all' },
+  )
 
-  const { muiRegister, watch, handleSubmit, required, formState, error } = form
-  const submitHandler = handleSubmit(onSubmitted)
+  const { muiRegister, watch, handleSubmit, required, formState } = form
+  const submitHandler = handleSubmit(() => {})
   const watchPassword = watch('password')
 
   const minPasswordLength = Number(
@@ -70,7 +78,7 @@ export function SignUpFormInline({
         <TextField
           variant='outlined'
           type='password'
-          error={!!formState.errors.password || !!error?.message}
+          error={!!formState.errors.password}
           label={<Trans id='Password' />}
           autoFocus
           autoComplete='new-password'
@@ -83,13 +91,12 @@ export function SignUpFormInline({
               message: i18n._(/* i18n */ 'Password must have at least 8 characters'),
             },
           })}
-          helperText={error?.message}
-          disabled={formState.isSubmitting && !error?.message}
+          disabled={formState.isSubmitting}
         />
         <TextField
           variant='outlined'
           type='password'
-          error={!!formState.errors.confirmPassword || !!error?.message}
+          error={!!formState.errors.confirmPassword}
           label={<Trans id='Confirm password' />}
           autoComplete='new-password'
           required
@@ -98,7 +105,7 @@ export function SignUpFormInline({
             validate: (value) => value === watchPassword,
           })}
           helperText={!!formState.errors.confirmPassword && <Trans id='Passwords should match' />}
-          disabled={formState.isSubmitting && !error?.message}
+          disabled={formState.isSubmitting}
         />
       </FormRow>
 
@@ -117,7 +124,7 @@ export function SignUpFormInline({
             <Button
               fullWidth
               type='submit'
-              loading={formState.isSubmitting && !error?.message}
+              loading={formState.isSubmitting}
               color='secondary'
               variant='pill'
             >
@@ -126,6 +133,7 @@ export function SignUpFormInline({
           </Box>
         </FormRow>
       </FormRow>
+      <ApolloErrorAlert error={form.error} />
     </Form>
   )
 }


### PR DESCRIPTION
Before:
![image](https://github.com/graphcommerce-org/graphcommerce/assets/62989724/b7724df1-ea9f-410d-b51b-14a565f8c8b5)

After:
![image](https://github.com/graphcommerce-org/graphcommerce/assets/62989724/efc5d20f-9414-4a5c-b0e8-42e76aa1b916)
