### PR TITLE
Disable appDir

### DIFF
--- a/.changeset/three-turkeys-cross.md
+++ b/.changeset/three-turkeys-cross.md
@@ -1,0 +1,5 @@
+---
+"@graphcommerce/magento-graphcms": patch
+---
+
+Disable appDir, this ensures jest-worker isn't used which can cause issues in standalone mode

--- a/examples/magento-graphcms/next.config.js
+++ b/examples/magento-graphcms/next.config.js
@@ -22,6 +22,9 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  experimental: {
+    appDir: false,
+  },
 }
 
 module.exports = withGraphCommerce(withPWA(nextConfig), __dirname)


### PR DESCRIPTION
We don't use this, and this ensures jest-worker isn't used which can cause issues in standalone mode. See also https://github.com/vercel/next.js/issues/45508