### PR TITLE
Allow duplicate Magento store locales

### DIFF
--- a/.changeset/new-toys-invent.md
+++ b/.changeset/new-toys-invent.md
@@ -1,0 +1,7 @@
+---
+'@graphcommerce/magento-product-configurable': minor
+'@graphcommerce/algolia-search': minor
+'@graphcommerce/next-config': minor
+---
+
+Multi website with multiple duplicates locales support. Use `en-us-website1`, `en-us-website2` as the locale declaration.

--- a/packages/algolia-search/hooks/useAlgoliaSearchIndexConfig.ts
+++ b/packages/algolia-search/hooks/useAlgoliaSearchIndexConfig.ts
@@ -1,8 +1,9 @@
 import { storefrontConfig } from '@graphcommerce/next-ui'
-import { i18n } from '@lingui/core'
+import { useRouter } from 'next/router'
 
 export function useAlgoliaSearchIndexConfig(suffix: string) {
-  return storefrontConfig(i18n.locale)?.algoliaSearchIndexConfig.find((ai) =>
+  const { locale } = useRouter()
+  return storefrontConfig(locale)?.algoliaSearchIndexConfig.find((ai) =>
     ai.searchIndex.includes(suffix),
   )
 }

--- a/packages/algolia-search/plugins/AlgoliaProductSortPlugin.tsx
+++ b/packages/algolia-search/plugins/AlgoliaProductSortPlugin.tsx
@@ -2,6 +2,7 @@ import { ProductFiltersProps } from '@graphcommerce/magento-product'
 import { IfConfig, PluginProps } from '@graphcommerce/next-config'
 import { storefrontConfig } from '@graphcommerce/next-ui'
 import { i18n } from '@lingui/core'
+import { useRouter } from 'next/router'
 import { useSortBy } from 'react-instantsearch-hooks-web'
 import { RenderChip } from '../components/Chip/RenderChip'
 
@@ -11,9 +12,13 @@ export const ifConfig: IfConfig = 'algoliaApplicationId'
 
 function AlgoliaProductSortPlugin(props: PluginProps<ProductFiltersProps>) {
   const { Prev, ...rest } = props
+  const { locale } = useRouter()
+  const options = storefrontConfig(locale)?.sortOptions
   const sort = useSortBy({
-    items: storefrontConfig(i18n.locale)?.sortOptions ?? [],
+    items: options ?? [],
   })
+
+  if (!options) return null
 
   return (
     <RenderChip

--- a/packages/magento-product-configurable/components/ConfigurableProductOptions/ConfigurableProductOptions.tsx
+++ b/packages/magento-product-configurable/components/ConfigurableProductOptions/ConfigurableProductOptions.tsx
@@ -57,7 +57,10 @@ export function ConfigurableProductOptions(props: ConfigurableProductOptionsProp
       .length === 0
 
   const allLabels = useMemo(() => {
-    const formatter = new Intl.ListFormat(locale, { style: 'long', type: 'conjunction' })
+    // Remove optional dialect from locale, which Intl.NumberFormat does not support.
+    const strippedLocale = locale?.split('-', 2).join('-')
+
+    const formatter = new Intl.ListFormat(strippedLocale, { style: 'long', type: 'conjunction' })
     return formatter.format(options.map((o) => o.label))
   }, [locale, options])
 

--- a/packages/next-ui/hooks/useDateTimeFormat.ts
+++ b/packages/next-ui/hooks/useDateTimeFormat.ts
@@ -5,6 +5,13 @@ export type DateTimeFormatProps = Intl.DateTimeFormatOptions
 
 export function useDateTimeFormat(props?: DateTimeFormatProps) {
   const { locale } = useRouter()
-  const formatter = useMemo(() => new Intl.DateTimeFormat(locale, props), [locale, props])
+
+  // Remove optional dialect from locale, which Intl.NumberFormat does not support.
+  const strippedLocale = locale?.split('-', 2).join('-')
+
+  const formatter = useMemo(
+    () => new Intl.DateTimeFormat(strippedLocale, props),
+    [strippedLocale, props],
+  )
   return formatter
 }

--- a/packages/next-ui/hooks/useNumberFormat.ts
+++ b/packages/next-ui/hooks/useNumberFormat.ts
@@ -5,6 +5,13 @@ export type NumberFormatProps = Intl.NumberFormatOptions
 
 export function useNumberFormat(props?: NumberFormatProps) {
   const { locale } = useRouter()
-  const formatter = useMemo(() => new Intl.NumberFormat(locale, props), [locale, props])
+
+  // Remove optional dialect from locale, which Intl.NumberFormat does not support.
+  const strippedLocale = locale?.split('-', 2).join('-')
+
+  const formatter = useMemo(
+    () => new Intl.NumberFormat(strippedLocale, props),
+    [strippedLocale, props],
+  )
   return formatter
 }

--- a/packagesDev/next-config/dist/withGraphCommerce.js
+++ b/packagesDev/next-config/dist/withGraphCommerce.js
@@ -17,21 +17,13 @@ function domains(config) {
         if (!loc.domain)
             return acc;
         acc[loc.domain] = {
-            defaultLocale: loc.defaultLocale ? loc.locale : acc[loc.domain]?.defaultLocale,
+            defaultLocale: loc.locale,
             locales: [...(acc[loc.domain]?.locales ?? []), loc.locale],
             domain: loc.domain,
-            http: true,
+            http: process.env.NODE_ENV === 'development' || undefined,
         };
         return acc;
     }, {}));
-}
-function remotePatterns(url) {
-    const urlObj = new URL(url);
-    return {
-        hostname: urlObj.hostname,
-        protocol: urlObj.protocol,
-        port: urlObj.port,
-    };
 }
 /**
  * GraphCommerce configuration: .
@@ -58,6 +50,7 @@ function withGraphCommerce(nextConfig, cwd) {
             swcPlugins: [...(nextConfig.experimental?.swcPlugins ?? []), ['@lingui/swc-plugin', {}]],
         },
         i18n: {
+            ...nextConfig.i18n,
             defaultLocale: storefront.find((locale) => locale.defaultLocale)?.locale ?? storefront[0].locale,
             locales: storefront.map((locale) => locale.locale),
             domains: [...domains(graphcommerceConfig), ...(nextConfig.i18n?.domains ?? [])],

--- a/packagesDev/next-config/src/withGraphCommerce.ts
+++ b/packagesDev/next-config/src/withGraphCommerce.ts
@@ -66,6 +66,7 @@ export function withGraphCommerce(nextConfig: NextConfig, cwd: string): NextConf
       swcPlugins: [...(nextConfig.experimental?.swcPlugins ?? []), ['@lingui/swc-plugin', {}]],
     },
     i18n: {
+      ...nextConfig.i18n,
       defaultLocale:
         storefront.find((locale) => locale.defaultLocale)?.locale ?? storefront[0].locale,
       locales: storefront.map((locale) => locale.locale),

--- a/packagesDev/next-config/src/withGraphCommerce.ts
+++ b/packagesDev/next-config/src/withGraphCommerce.ts
@@ -17,7 +17,7 @@ function domains(config: GraphCommerceConfig): DomainLocale[] {
       if (!loc.domain) return acc
 
       acc[loc.domain] = {
-        defaultLocale: loc.defaultLocale ? loc.locale : acc[loc.domain]?.defaultLocale,
+        defaultLocale: loc.locale,
         locales: [...(acc[loc.domain]?.locales ?? []), loc.locale],
         domain: loc.domain,
         http: true,

--- a/packagesDev/next-config/src/withGraphCommerce.ts
+++ b/packagesDev/next-config/src/withGraphCommerce.ts
@@ -2,7 +2,6 @@ import CircularDependencyPlugin from 'circular-dependency-plugin'
 import { DuplicatesPlugin } from 'inspectpack/plugin'
 import type { NextConfig } from 'next'
 import { DomainLocale } from 'next/dist/server/config'
-import { RemotePattern } from 'next/dist/shared/lib/image-config'
 import { DefinePlugin, Configuration } from 'webpack'
 import { loadConfig } from './config/loadConfig'
 import { configToImportMeta } from './config/utils/configToImportMeta'
@@ -27,15 +26,6 @@ function domains(config: GraphCommerceConfig): DomainLocale[] {
       return acc
     }, {} as Record<string, DomainLocale>),
   )
-}
-
-function remotePatterns(url: string): RemotePattern {
-  const urlObj = new URL(url)
-  return {
-    hostname: urlObj.hostname,
-    protocol: urlObj.protocol as RemotePattern['protocol'],
-    port: urlObj.port,
-  }
 }
 
 /**

--- a/packagesDev/next-config/src/withGraphCommerce.ts
+++ b/packagesDev/next-config/src/withGraphCommerce.ts
@@ -20,7 +20,7 @@ function domains(config: GraphCommerceConfig): DomainLocale[] {
         defaultLocale: loc.locale,
         locales: [...(acc[loc.domain]?.locales ?? []), loc.locale],
         domain: loc.domain,
-        http: true,
+        http: process.env.NODE_ENV === 'development' || undefined,
       } as DomainLocale
 
       return acc


### PR DESCRIPTION
These changes allow the use of locales such as `nl-nl-mystore`, `nl-nl-foostore`, etc. in next to connect with different Magento stores which have the same locale (i.e. `nl-nl`), but where i18n features (routing, translations, formatting etc) still works as expected.

In addition there are some fixes that make i18n domain routing work. You must set the `domain` field in your `GraphCommerceStorefrontConfig` config for this to function. You will also likely want to disable locale auto-redirection (`nextConfig.i18n.localeDetection`)

Some TODOs in this PR:
- Documentation (example setup)
- Test if/how `www.` subdomains work
- General testing