### PR TITLE
Feature/gcom 1120 | Improve defaultConfigurableOptionsSelection functionality 

### DIFF
--- a/.changeset/gentle-crews-fetch.md
+++ b/.changeset/gentle-crews-fetch.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/magento-product-configurable': patch
+---
+
+Make sure the products and relatedUpsells queries are merged correctly

--- a/.changeset/perfect-buckets-talk.md
+++ b/.changeset/perfect-buckets-talk.md
@@ -1,5 +1,5 @@
 ---
-'@graphcommerce/magento-product-configurable': minor
+'@graphcommerce/magento-product-configurable': patch
 ---
 
-improve default selected options functionality
+Remove the requirement to query attributes on simple for simple products when `configurableVariantForSimple` is enabled and use the `variants` of the configurable product.

--- a/.changeset/perfect-buckets-talk.md
+++ b/.changeset/perfect-buckets-talk.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/magento-product-configurable': minor
+---
+
+improve default selected options functionality

--- a/.changeset/perfect-jeans-sell.md
+++ b/.changeset/perfect-jeans-sell.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/magento-product-configurable': patch
+---
+
+Added an opt-in configuration `configurableVariantForSimple` that allows rendering of a configurable product page on a simple product URL with the options pre-selected.

--- a/docs/framework/config.md
+++ b/docs/framework/config.md
@@ -120,6 +120,19 @@ Use compare functionality
 By default the compare feature is denoted with a 'compare ICON' (2 arrows facing one another).
 This may be fine for experienced users, but for more clarity it's also possible to present the compare feature as a CHECKBOX accompanied by the 'Compare' label
 
+#### `configurableVariantForSimple: Boolean (default: [object Object])`
+
+If a simple product is part of a Configurable product page, should the simple product be
+rendered as a configured option of the configurable product page?
+
+How does this work:
+
+When the `products(filters: { url_key: { eq: 'simple-product' } }) { ... }` query is ran,
+Magento also returns the Simple product and the Configurable product the simple belongs to.
+
+If that is the case we render the configurable product page instead of the simple product page but
+the options to select the simple product are pre-selected.
+
 #### `customerRequireEmailConfirmation: Boolean`
 
 Due to a limitation in the GraphQL API of Magento 2, we need to know if the

--- a/examples/magento-graphcms/pages/p/[url].tsx
+++ b/examples/magento-graphcms/pages/p/[url].tsx
@@ -68,7 +68,11 @@ type GetPageStaticProps = GetStaticProps<LayoutNavigationProps, Props, RouteProp
 function ProductPage(props: Props) {
   const { products, relatedUpsells, usps, sidebarUsps, pages, defaultValues } = props
 
-  const product = mergeDeep(products, relatedUpsells)?.items?.[0]
+  const product = mergeDeep(
+    products?.items?.[0],
+    relatedUpsells?.items?.find((item) => item?.uid === products?.items?.[0]?.uid),
+  )
+
   if (!product?.sku || !product.url_key) return null
 
   return (

--- a/packages/demo-magento-graphcommerce/graphql/demo/DemoProductPageItem.graphql
+++ b/packages/demo-magento-graphcommerce/graphql/demo/DemoProductPageItem.graphql
@@ -1,6 +1,0 @@
-fragment DemoProductPageItem on SimpleProduct
-@inject(into: ["ProductPageItem"])
-@env(if: "DEMO_MAGENTO_GRAPHCOMMERCE") {
-  size
-  print_pattern_swatch
-}

--- a/packages/magento-product-configurable/Config.graphqls
+++ b/packages/magento-product-configurable/Config.graphqls
@@ -1,0 +1,15 @@
+extend input GraphCommerceConfig {
+  """
+  If a simple product is part of a Configurable product page, should the simple product be
+  rendered as a configured option of the configurable product page?
+
+  How does this work:
+
+  When the `products(filters: { url_key: { eq: 'simple-product' } }) { ... }` query is ran,
+  Magento also returns the Simple product and the Configurable product the simple belongs to.
+
+  If that is the case we render the configurable product page instead of the simple product page but
+  the options to select the simple product are pre-selected.
+  """
+  configurableVariantForSimple: Boolean = false
+}

--- a/packages/magento-product-configurable/graphql/ConfigurableOptions.graphql
+++ b/packages/magento-product-configurable/graphql/ConfigurableOptions.graphql
@@ -26,24 +26,9 @@ fragment ConfigurableOptions on ConfigurableProduct {
     attributes {
       code
       uid
-      label
     }
     product {
       uid
-      sku
-      name
-      price_range {
-        minimum_price {
-          final_price {
-            value
-          }
-        }
-        maximum_price {
-          final_price {
-            value
-          }
-        }
-      }
     }
   }
 }

--- a/packages/magento-product-configurable/graphql/ConfigurableOptions.graphql
+++ b/packages/magento-product-configurable/graphql/ConfigurableOptions.graphql
@@ -22,4 +22,28 @@ fragment ConfigurableOptions on ConfigurableProduct {
       ...ConfigurableOptionValue
     }
   }
+  variants {
+    attributes {
+      code
+      uid
+      label
+    }
+    product {
+      uid
+      sku
+      name
+      price_range {
+        minimum_price {
+          final_price {
+            value
+          }
+        }
+        maximum_price {
+          final_price {
+            value
+          }
+        }
+      }
+    }
+  }
 }

--- a/packages/magento-product-configurable/graphql/ConfiguredVariant.graphql
+++ b/packages/magento-product-configurable/graphql/ConfiguredVariant.graphql
@@ -2,6 +2,7 @@ fragment ConfiguredVariant on SimpleProduct @injectable {
   __typename
   uid
   name
+  sku
   price_range {
     minimum_price {
       final_price {

--- a/packages/magento-product-configurable/graphql/ConfiguredVariant.graphql
+++ b/packages/magento-product-configurable/graphql/ConfiguredVariant.graphql
@@ -2,7 +2,6 @@ fragment ConfiguredVariant on SimpleProduct @injectable {
   __typename
   uid
   name
-  sku
   price_range {
     minimum_price {
       final_price {

--- a/packages/magento-product-configurable/utils/defaultConfigurableOptionsSelection.ts
+++ b/packages/magento-product-configurable/utils/defaultConfigurableOptionsSelection.ts
@@ -24,9 +24,9 @@ export function defaultConfigurableOptionsSelection<Q extends BaseQuery = BaseQu
 
   const configurable = findByTypename(query?.products?.items, 'ConfigurableProduct')
   const variants = configurable?.variants
-  const simple = findByTypename(query?.products?.items, 'SimpleProduct')
+  const simple = requested
 
-  if (!configurable?.url_key || !simple) return { ...query, products: { items: [requested] } }
+  if (!configurable?.url_key) return { ...query, products: { items: [requested] } }
 
   const selectedOptions: string[] = []
 

--- a/packages/magento-product-configurable/utils/defaultConfigurableOptionsSelection.ts
+++ b/packages/magento-product-configurable/utils/defaultConfigurableOptionsSelection.ts
@@ -25,7 +25,6 @@ export function defaultConfigurableOptionsSelection<Q extends BaseQuery = BaseQu
   const configurable = findByTypename(query?.products?.items, 'ConfigurableProduct')
   const variants = configurable?.variants
   const simple = findByTypename(query?.products?.items, 'SimpleProduct')
-  const simpleSku = simple?.sku
 
   if (!configurable?.url_key || !simple) return { ...query, products: { items: [requested] } }
 

--- a/packages/magento-product-configurable/utils/defaultConfigurableOptionsSelection.ts
+++ b/packages/magento-product-configurable/utils/defaultConfigurableOptionsSelection.ts
@@ -48,8 +48,7 @@ export function defaultConfigurableOptionsSelection<Q extends BaseQuery = BaseQu
    * https://hoproj.atlassian.net/browse/GCOM-1120
    */
   variants?.forEach((v) => {
-    const vSku = v?.product?.sku
-    if (vSku === simpleSku) {
+    if (v?.product?.uid === simple.uid) {
       v?.attributes?.forEach((a) => {
         const indexOfOption = options.findIndex((o) => o.attribute_code === a?.code)
         selectedOptions[indexOfOption] = a?.uid ?? ''

--- a/packages/magento-product-configurable/utils/defaultConfigurableOptionsSelection.ts
+++ b/packages/magento-product-configurable/utils/defaultConfigurableOptionsSelection.ts
@@ -27,6 +27,9 @@ export function defaultConfigurableOptionsSelection<Q extends BaseQuery = BaseQu
   client: ApolloClient<object>,
   query: Q,
 ): Q & Pick<AddProductsToCartFormProps, 'defaultValues'> {
+  if (!import.meta.graphCommerce.configurableVariantForSimple)
+    return { ...query, defaultValues: {} }
+
   const simple = query?.products?.items?.find((p) => p?.url_key === urlKey)
   const configurable = findByTypename(query?.products?.items, 'ConfigurableProduct')
 

--- a/packages/magento-product-configurable/utils/defaultConfigurableOptionsSelection.ts
+++ b/packages/magento-product-configurable/utils/defaultConfigurableOptionsSelection.ts
@@ -39,11 +39,8 @@ export function defaultConfigurableOptionsSelection<Q extends BaseQuery = BaseQu
     (v) => v?.product?.uid === simple?.uid,
   )?.attributes
 
-  // If we can't find the simple product as one of the configurable product variants, just return the simple
-  if (!attributes) return { ...query, products: { items: [simple] } }
-
-  const selectedOptions = attributes.filter(nonNullable).map((a) => a.uid)
-  if (!selectedOptions.length) return { ...query, defaultValues: {} }
+  const selectedOptions = (attributes ?? []).filter(nonNullable).map((a) => a.uid)
+  if (!selectedOptions.length) return { ...query, products: { items: [simple] }, defaultValues: {} }
 
   /**
    * We're using writeQuery to the Apollo Client cache, to to avoid a second request to the GraphQL

--- a/packages/magento-product-configurable/utils/defaultConfigurableOptionsSelection.ts
+++ b/packages/magento-product-configurable/utils/defaultConfigurableOptionsSelection.ts
@@ -33,8 +33,8 @@ export function defaultConfigurableOptionsSelection<Q extends BaseQuery = BaseQu
   const options = filterNonNullableKeys(configurable.configurable_options)
 
   /**
-   * A new feature was implemented where a simple product displays the options of a configurable
-   * product. On the simple product page the options of the current product are preselected.
+   * A simple product displays the options of a configurable product. On the simple product page the
+   * options of the current variant are preselected.
    *
    * (e.g. width: 12mm | 15mm | 25mm => 25mm is preselected).
    *

--- a/packagesDev/next-config/dist/config/demoConfig.js
+++ b/packagesDev/next-config/dist/config/demoConfig.js
@@ -25,4 +25,5 @@ exports.demoConfig = {
     demoMode: true,
     limitSsg: true,
     compare: true,
+    configurableVariantForSimple: true,
 };

--- a/packagesDev/next-config/dist/generated/config.js
+++ b/packagesDev/next-config/dist/generated/config.js
@@ -48,6 +48,7 @@ function GraphCommerceConfigSchema() {
         cartDisplayPricesInclTax: _zod.z.boolean().nullish(),
         compare: _zod.z.boolean().nullish(),
         compareVariant: CompareVariantSchema.nullish(),
+        configurableVariantForSimple: _zod.z.boolean().nullish(),
         customerRequireEmailConfirmation: _zod.z.boolean().nullish(),
         debug: GraphCommerceDebugConfigSchema().nullish(),
         demoMode: _zod.z.boolean().nullish(),

--- a/packagesDev/next-config/src/config/demoConfig.ts
+++ b/packagesDev/next-config/src/config/demoConfig.ts
@@ -27,4 +27,5 @@ export const demoConfig: PartialDeep<GraphCommerceConfig, { recurseIntoArrays: t
   demoMode: true,
   limitSsg: true,
   compare: true,
+  configurableVariantForSimple: true,
 }

--- a/packagesDev/next-config/src/generated/config.ts
+++ b/packagesDev/next-config/src/generated/config.ts
@@ -121,6 +121,19 @@ export type GraphCommerceConfig = {
    */
   compareVariant?: InputMaybe<CompareVariant>;
   /**
+   * If a simple product is part of a Configurable product page, should the simple product be
+   * rendered as a configured option of the configurable product page?
+   *
+   * How does this work:
+   *
+   * When the `products(filters: { url_key: { eq: 'simple-product' } }) { ... }` query is ran,
+   * Magento also returns the Simple product and the Configurable product the simple belongs to.
+   *
+   * If that is the case we render the configurable product page instead of the simple product page but
+   * the options to select the simple product are pre-selected.
+   */
+  configurableVariantForSimple?: InputMaybe<Scalars['Boolean']['input']>;
+  /**
    * Due to a limitation in the GraphQL API of Magento 2, we need to know if the
    * customer requires email confirmation.
    *
@@ -353,6 +366,7 @@ export function GraphCommerceConfigSchema(): z.ZodObject<Properties<GraphCommerc
     cartDisplayPricesInclTax: z.boolean().nullish(),
     compare: z.boolean().nullish(),
     compareVariant: CompareVariantSchema.nullish(),
+    configurableVariantForSimple: z.boolean().nullish(),
     customerRequireEmailConfirmation: z.boolean().nullish(),
     debug: GraphCommerceDebugConfigSchema().nullish(),
     demoMode: z.boolean().nullish(),


### PR DESCRIPTION
In this PR: 

**1. Improve defaultConfigurableOptionsSelection functionality**

_Situation: You land on a simple product page._ 

In the current main branch, we check all the configurableOptions of the linked configurable item. If a simple product does not have this option as a property on it's product branch, the option can not be configured on the simple product page. To fix this, you had to query that option in your productPage query to make it a property on the simple product. This however meant that you had to add a property to your query every time a site owner made a new configurable option. This is not dynamic nor scalable. 

To fix this:
We check the variants of a configurable option and match the variant SKU's with the SKU of the current simple product. When we know which variant should be preselected, we get the uid(s) from the variant's attribute(s) and inject them into the selectedOptions array. 

**2. Match the CORRECT related upsells with the CORRECT product**
In the current main branch, the first item of the relatedUpsells array is being merged into the product object. But in case of a simple product, magento not only gives the simple product back, but also optional configurable products that are linked to it. Merging relatedUpsells[0] with the simple product will result in merging the wrong upsells with the simple product.

**Test url** 
_Please replace localhost for Vercel URL._ 
Simple product: localhost:3000/p/waverly-size-4-6y-gc-564-sock-6y 
Concurrent configurable product: localhost:3000/p/gc-fruity-sock

**Issues:** 
1. If there is more than 1 configurable matched to a simple product, the simple product will only render the options of the first configurable returned in the productPage array.  This can cause potential issues, for instance, when someone is on the page of the second configurable linked to the simple, presses on an option, gets redirects to the simple and then suddenly some options that were unique on the second configurable are now longer showing as options. I did not validate this theory.