### PR TITLE
bug(GCOM-1114) added onMouseDown eventhandler

### DIFF
--- a/.changeset/dirty-toes-breathe.md
+++ b/.changeset/dirty-toes-breathe.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/framer-scroller': patch
+---
+
+Added event.preventDefault() to scroller

--- a/.changeset/dirty-toes-breathe.md
+++ b/.changeset/dirty-toes-breathe.md
@@ -2,4 +2,4 @@
 '@graphcommerce/framer-scroller': patch
 ---
 
-Added event.preventDefault() to scroller
+Fixed scrollers not working properly in Firefox due to the `draggable` html property being handled differently. Added event.preventDefault() onMouseDown to useScroller to prevent drag and drop functionality inside scrollers.

--- a/packages/framer-scroller/components/Scroller.tsx
+++ b/packages/framer-scroller/components/Scroller.tsx
@@ -13,13 +13,7 @@ export const Scroller = forwardRef<HTMLDivElement, ScrollableProps & { sx?: SxPr
       forwardedRef,
     )
 
-    return (
-      <ScrollerDiv
-        onMouseDown={(event) => event.preventDefault()}
-        {...scroller}
-        sx={[scroller.sx, ...(Array.isArray(sx) ? sx : [sx])]}
-      />
-    )
+    return <ScrollerDiv {...scroller} sx={[scroller.sx, ...(Array.isArray(sx) ? sx : [sx])]} />
   },
 )
 Scroller.displayName = 'Scroller'

--- a/packages/framer-scroller/components/Scroller.tsx
+++ b/packages/framer-scroller/components/Scroller.tsx
@@ -13,7 +13,13 @@ export const Scroller = forwardRef<HTMLDivElement, ScrollableProps & { sx?: SxPr
       forwardedRef,
     )
 
-    return <ScrollerDiv {...scroller} sx={[scroller.sx, ...(Array.isArray(sx) ? sx : [sx])]} />
+    return (
+      <ScrollerDiv
+        onMouseDown={(event) => event.preventDefault()}
+        {...scroller}
+        sx={[scroller.sx, ...(Array.isArray(sx) ? sx : [sx])]}
+      />
+    )
   },
 )
 Scroller.displayName = 'Scroller'

--- a/packages/framer-scroller/hooks/useScroller.ts
+++ b/packages/framer-scroller/hooks/useScroller.ts
@@ -10,7 +10,7 @@ import {
   useDomEvent,
   useTransform,
 } from 'framer-motion'
-import React, { ReactHTML, useEffect, useState } from 'react'
+import React, { MouseEventHandler, ReactHTML, useEffect, useState } from 'react'
 import { isHTMLMousePointerEvent } from '../utils/isHTMLMousePointerEvent'
 import { scrollSnapTypeDirection, SnapTypeDirection } from '../utils/scrollSnapTypeDirection'
 import { useScrollerContext } from './useScrollerContext'
@@ -101,6 +101,8 @@ export function useScroller<
     disableSnap()
     setPanning(true)
   }
+
+  const onMouseDown: MouseEventHandler<HTMLDivElement> = (event) => event.preventDefault()
 
   const onPan: PanHandlers['onPan'] = (event, info: PanInfo) => {
     if (!scrollerRef.current) return
@@ -289,6 +291,7 @@ export function useScroller<
     onPanStart,
     onPan,
     onPanEnd,
+    onMouseDown,
     children,
     className: `${classes.root} ${props.className}`,
     sx,


### PR DESCRIPTION
Added event.preventDefault() because firefox did noice the onPan eventhandler and because of that it dragged the picture instead of swiped the scroller.