### PR TITLE
Fix/conditional footer components

### DIFF
--- a/.changeset/yellow-jobs-compare.md
+++ b/.changeset/yellow-jobs-compare.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/next-ui': patch
+---
+
+Footer components should be rendered conditionally

--- a/.changeset/yellow-jobs-compare.md
+++ b/.changeset/yellow-jobs-compare.md
@@ -2,4 +2,4 @@
 '@graphcommerce/next-ui': patch
 ---
 
-Footer components should be rendered conditionally
+Footer's grid-area's will only be rendered when the props are passed.

--- a/packages/next-ui/Footer/Footer.tsx
+++ b/packages/next-ui/Footer/Footer.tsx
@@ -65,63 +65,71 @@ export function Footer(props: FooterProps) {
       className={classes.root}
       {...containerProps}
     >
-      <Box
-        sx={(theme) => ({
-          display: 'grid',
-          justifyContent: 'start',
-          gridAutoFlow: 'column',
-          gridArea: 'social',
-          gap: { xs: `0 ${theme.spacings.xs}`, md: `0 ${theme.spacings.xs}` },
-          '& > *': {
-            minWidth: 'min-content',
-          },
-        })}
-        className={classes.social}
-      >
-        {socialLinks}
-      </Box>
-      <Box
-        sx={(theme) => ({
-          gridArea: 'switcher',
-          justifySelf: 'end',
-          [theme.breakpoints.down('md')]: {
-            justifySelf: 'center',
-          },
-        })}
-        className={classes.storeSwitcher}
-      >
-        {storeSwitcher}
-      </Box>
-      <Box
-        sx={(theme) => ({
-          gridArea: 'support',
-          justifySelf: 'flex-end',
-          [theme.breakpoints.down('md')]: {
-            justifySelf: 'center',
-          },
-        })}
-        className={classes.support}
-      >
-        {customerService}
-      </Box>
-      <Box
-        sx={(theme) => ({
-          typography: 'body2',
-          display: 'grid',
-          gridAutoFlow: 'column',
-          alignContent: 'center',
-          gridArea: 'links',
-          gap: theme.spacings.sm,
-          [theme.breakpoints.down('md')]: {
-            gridAutoFlow: 'row',
-            textAlign: 'center',
-            gap: `8px`,
-          },
-        })}
-        className={classes.copyright}
-      >
-        {copyright}
-      </Box>
+      {socialLinks && (
+        <Box
+          sx={(theme) => ({
+            display: 'grid',
+            justifyContent: 'start',
+            gridAutoFlow: 'column',
+            gridArea: 'social',
+            gap: { xs: `0 ${theme.spacings.xs}`, md: `0 ${theme.spacings.xs}` },
+            '& > *': {
+              minWidth: 'min-content',
+            },
+          })}
+          className={classes.social}
+        >
+          {socialLinks}
+        </Box>
+      )}
+      {storeSwitcher && (
+        <Box
+          sx={(theme) => ({
+            gridArea: 'switcher',
+            justifySelf: 'end',
+            [theme.breakpoints.down('md')]: {
+              justifySelf: 'center',
+            },
+          })}
+          className={classes.storeSwitcher}
+        >
+          {storeSwitcher}
+        </Box>
+      )}
+      {customerService && (
+        <Box
+          sx={(theme) => ({
+            gridArea: 'support',
+            justifySelf: 'flex-end',
+            [theme.breakpoints.down('md')]: {
+              justifySelf: 'center',
+            },
+          })}
+          className={classes.support}
+        >
+          {customerService}
+        </Box>
+      )}
+      {copyright && (
+        <Box
+          sx={(theme) => ({
+            typography: 'body2',
+            display: 'grid',
+            gridAutoFlow: 'column',
+            alignContent: 'center',
+            gridArea: 'links',
+            gap: theme.spacings.sm,
+            [theme.breakpoints.down('md')]: {
+              gridAutoFlow: 'row',
+              textAlign: 'center',
+              gap: `8px`,
+            },
+          })}
+          className={classes.copyright}
+        >
+          {copyright}
+        </Box>
+      )}
     </Container>
   )
 }


### PR DESCRIPTION
If, for example, storeSwitcher is not passed, the corresponding container shouldn’t be rendered either. This prevents unnecessary HTML.

—

Gaps could be created with the current grid-template when removing an item. The grid could be rewritten to respond to adding or removing items, but that seems a bit to complex for a demo template. Developers can also easily re-assign a component to another grid-area.