### PR TITLE
Crosssells improvements (GCOM-1138)

### DIFF
--- a/.changeset/quiet-tomatoes-melt.md
+++ b/.changeset/quiet-tomatoes-melt.md
@@ -1,0 +1,6 @@
+---
+'@graphcommerce/magento-product': patch
+'@graphcommerce/react-hook-form': patch
+---
+
+Reconstruct crosssells behaviour. Add submitted variables & showSuccess to RHF

--- a/docs/framework/config.md
+++ b/docs/framework/config.md
@@ -260,6 +260,12 @@ By default we route products to /p/[url] but you can change this to /product/[ur
 Default: '/p/'
 Example: '/product/'
 
+#### `redirectCrossSellItems: Boolean`
+
+Determines if, after adding a cross-sell item to the cart, the user should be redirected to the cross-sell items of the product they just added.
+
+Default: 'false'
+
 #### `robotsAllow: Boolean`
 
 Allow the site to be indexed by search engines.

--- a/docs/framework/config.md
+++ b/docs/framework/config.md
@@ -139,6 +139,18 @@ When a user selects a variant, it will switch the values on the configurable pag
 
 Enabling options here will allow switching of those variants.
 
+#### `crossSellsHideCartItems: Boolean (default: [object Object])`
+
+Determines if cross sell items should be shown when the user already has the product in their cart. This will result in a product will popping off the screen when you add it to the cart.
+
+Default: 'false'
+
+#### `crossSellsRedirectItems: Boolean (default: [object Object])`
+
+Determines if, after adding a cross-sell item to the cart, the user should be redirected to the cross-sell items of the product they just added.
+
+Default: 'false'
+
 #### `customerRequireEmailConfirmation: Boolean`
 
 Due to a limitation in the GraphQL API of Magento 2, we need to know if the
@@ -259,12 +271,6 @@ By default we route products to /p/[url] but you can change this to /product/[ur
 
 Default: '/p/'
 Example: '/product/'
-
-#### `redirectCrossSellItems: Boolean`
-
-Determines if, after adding a cross-sell item to the cart, the user should be redirected to the cross-sell items of the product they just added.
-
-Default: 'false'
 
 #### `robotsAllow: Boolean`
 

--- a/examples/magento-graphcms/pages/checkout/added.tsx
+++ b/examples/magento-graphcms/pages/checkout/added.tsx
@@ -33,10 +33,9 @@ function CheckoutAdded() {
   const { sku } = router.query
   const lastItem = items.find((item) => item.product.sku === sku)
 
-  const hideCrossSellItemsInCart =
-    false || Boolean(import.meta.graphCommerce.hideCrossSellItemsInCart)
+  const hideCrossSellItemsInCart = Boolean(import.meta.graphCommerce.hideCrossSellItemsInCart)
 
-  const redirectCrossSellItems = true || Boolean(import.meta.graphCommerce.redirectCrossSellItems)
+  const redirectCrossSellItems = Boolean(import.meta.graphCommerce.redirectCrossSellItems)
 
   const crosssels = useQuery(CrosssellsDocument, {
     variables: { pageSize: 1, filters: { sku: { eq: lastItem?.product.sku } } },
@@ -60,7 +59,6 @@ function CheckoutAdded() {
       items,
     ],
   )
-
   return (
     <>
       <PageMeta title={i18n._(/* i18n */ 'Cart')} metaRobots={['noindex']} />

--- a/examples/magento-graphcms/pages/checkout/added.tsx
+++ b/examples/magento-graphcms/pages/checkout/added.tsx
@@ -146,7 +146,7 @@ function CheckoutAdded() {
               <Trans id='Complete your purchase' />
             </Typography>
           </Container>
-          <AddProductsToCartForm disableSnackbar redirect={false}>
+          <AddProductsToCartForm disableSuccessSnackbar redirect={false}>
             <ItemScroller
               sx={(theme) => ({
                 width: 'auto',

--- a/examples/magento-graphcms/pages/checkout/added.tsx
+++ b/examples/magento-graphcms/pages/checkout/added.tsx
@@ -146,7 +146,7 @@ function CheckoutAdded() {
               <Trans id='Complete your purchase' />
             </Typography>
           </Container>
-          <AddProductsToCartForm disabledSnackbar redirect={false}>
+          <AddProductsToCartForm disableSnackbar redirect={false}>
             <ItemScroller
               sx={(theme) => ({
                 width: 'auto',

--- a/examples/magento-graphcms/pages/checkout/added.tsx
+++ b/examples/magento-graphcms/pages/checkout/added.tsx
@@ -43,11 +43,8 @@ function CheckoutAdded() {
       filterNonNullableKeys(
         crosssels.data?.products?.items?.[0]?.crosssell_products ??
           crosssels.previousData?.products?.items?.[0]?.crosssell_products,
-      ).filter(
-        (item) =>
-          items.every((i) => i.product.sku !== item.sku) && item.stock_status === 'IN_STOCK',
-      ),
-    [crosssels.data?.products?.items, crosssels.previousData?.products?.items, items],
+      ).filter((item) => item.stock_status === 'IN_STOCK'),
+    [crosssels.data?.products?.items, crosssels.previousData?.products?.items],
   )
 
   return (
@@ -149,7 +146,7 @@ function CheckoutAdded() {
               <Trans id='Complete your purchase' />
             </Typography>
           </Container>
-          <AddProductsToCartForm>
+          <AddProductsToCartForm disabledSnackbar redirect={false}>
             <ItemScroller
               sx={(theme) => ({
                 width: 'auto',

--- a/examples/magento-graphcms/pages/checkout/added.tsx
+++ b/examples/magento-graphcms/pages/checkout/added.tsx
@@ -32,6 +32,7 @@ function CheckoutAdded() {
   const router = useRouter()
   const { sku } = router.query
   const lastItem = items.find((item) => item.product.sku === sku)
+  const redirectCrossSellItems = `${import.meta.graphCommerce.redirectCrossSellItems}`
 
   const crosssels = useQuery(CrosssellsDocument, {
     variables: { pageSize: 1, filters: { sku: { eq: lastItem?.product.sku } } },
@@ -146,7 +147,7 @@ function CheckoutAdded() {
               <Trans id='Complete your purchase' />
             </Typography>
           </Container>
-          <AddProductsToCartForm disableSuccessSnackbar redirect={false}>
+          <AddProductsToCartForm disableSuccessSnackbar redirect={redirectCrossSellItems}>
             <ItemScroller
               sx={(theme) => ({
                 width: 'auto',

--- a/packages/magento-cart/components/CartAdded/index.ts
+++ b/packages/magento-cart/components/CartAdded/index.ts
@@ -1,2 +1,3 @@
 export * from './CartAdded.gql'
 export * from './Crosssells.gql'
+export * from './useCrosssellItems'

--- a/packages/magento-cart/components/CartAdded/useCrosssellItems.ts
+++ b/packages/magento-cart/components/CartAdded/useCrosssellItems.ts
@@ -1,0 +1,36 @@
+import { useQuery } from '@graphcommerce/graphql'
+import { filterNonNullableKeys } from '@graphcommerce/next-ui'
+import { useRouter } from 'next/router'
+import { useMemo } from 'react'
+import { useCartQuery } from '../../hooks'
+import { CartAddedDocument } from './CartAdded.gql'
+import { CrosssellsDocument } from './Crosssells.gql'
+
+const crossSellsHideCartItems = Boolean(import.meta.graphCommerce.crossSellsHideCartItems)
+
+export function useCrosssellItems() {
+  const cartAdded = useCartQuery(CartAddedDocument)
+  const items = filterNonNullableKeys(cartAdded.data?.cart?.items)
+  const router = useRouter()
+  const addedItem = items.find((item) => item.product.sku === router.query.sku)
+
+  const crosssels = useQuery(CrosssellsDocument, {
+    variables: { pageSize: 1, filters: { sku: { eq: addedItem?.product.sku } } },
+    skip: !addedItem?.product.sku,
+  })
+
+  const data =
+    crosssels.data?.products?.items?.[0]?.crosssell_products ??
+    crosssels.previousData?.products?.items?.[0]?.crosssell_products
+
+  const crossSellItems = useMemo(
+    () =>
+      filterNonNullableKeys(data)
+        .filter((item) => item.stock_status === 'IN_STOCK')
+        .filter(
+          (item) => !crossSellsHideCartItems || items.every((i) => i.product.sku !== item.sku),
+        ),
+    [data, items],
+  )
+  return [addedItem, crossSellItems] as const
+}

--- a/packages/magento-product/Config.graphqls
+++ b/packages/magento-product/Config.graphqls
@@ -37,12 +37,12 @@ extend input GraphCommerceConfig {
 
   Default: 'false'
   """
-  redirectCrossSellItems: Boolean
+  crossSellsRedirectItems: Boolean =  false
 
   """
   Determines if cross sell items should be shown when the user already has the product in their cart. This will result in a product will popping off the screen when you add it to the cart.
 
   Default: 'false'
   """
-  hideCrossSellItemsInCart: Boolean
+  crossSellsHideCartItems: Boolean = false
 }

--- a/packages/magento-product/Config.graphqls
+++ b/packages/magento-product/Config.graphqls
@@ -31,4 +31,11 @@ extend input GraphCommerceConfig {
   Example: '/product/'
   """
   productRoute: String
+
+  """
+  Determines if, after adding a cross-sell item to the cart, the user should be redirected to the cross-sell items of the product they just added.
+
+  Default: 'false'
+  """
+  redirectCrossSellItems: Boolean
 }

--- a/packages/magento-product/Config.graphqls
+++ b/packages/magento-product/Config.graphqls
@@ -38,4 +38,11 @@ extend input GraphCommerceConfig {
   Default: 'false'
   """
   redirectCrossSellItems: Boolean
+
+  """
+  Determines if cross sell items should be shown when the user already has the product in their cart. This will result in a product will popping off the screen when you add it to the cart.
+
+  Default: 'false'
+  """
+  hideCrossSellItemsInCart: Boolean
 }

--- a/packages/magento-product/components/AddProductsToCart/AddProductsToCartButton.tsx
+++ b/packages/magento-product/components/AddProductsToCart/AddProductsToCartButton.tsx
@@ -25,7 +25,7 @@ export function AddProductsToCartButton(props: AddProductsToCartButtonProps) {
 
   return (
     <Button type='submit' color='primary' variant='pill' size='large' {...rest} {...action}>
-      {children || <Trans id='Add to Cart' />}
+      {children || action.showSuccess ? <Trans id='Added to Cart' /> : <Trans id='Add to Cart' />}
     </Button>
   )
 }

--- a/packages/magento-product/components/AddProductsToCart/AddProductsToCartButton.tsx
+++ b/packages/magento-product/components/AddProductsToCart/AddProductsToCartButton.tsx
@@ -25,7 +25,7 @@ export function AddProductsToCartButton(props: AddProductsToCartButtonProps) {
 
   return (
     <Button type='submit' color='primary' variant='pill' size='large' {...rest} {...action}>
-      {children || action.showSuccess ? <Trans id='Added to Cart' /> : <Trans id='Add to Cart' />}
+      {children || <Trans id='Add to Cart' />}
     </Button>
   )
 }

--- a/packages/magento-product/components/AddProductsToCart/AddProductsToCartFab.tsx
+++ b/packages/magento-product/components/AddProductsToCart/AddProductsToCartFab.tsx
@@ -1,4 +1,4 @@
-import { Fab, FabProps, iconShoppingBag } from '@graphcommerce/next-ui'
+import { Fab, FabProps, iconShoppingBag, iconCheckmark } from '@graphcommerce/next-ui'
 import { i18n } from '@lingui/core'
 import { SxProps, Theme } from '@mui/material'
 import {
@@ -13,14 +13,14 @@ export type AddProductsToCartFabProps = {
   UseAddProductsToCartActionProps
 
 export function AddProductsToCartFab(props: AddProductsToCartFabProps) {
-  const { icon = iconShoppingBag, product, ...rest } = props
+  const { icon = iconShoppingBag, product, sku, ...rest } = props
   const action = useAddProductsToCartAction(props)
   return (
     <Fab
       type='submit'
       {...rest}
       {...action}
-      icon={icon}
+      icon={action.showSuccess ? iconCheckmark : icon}
       aria-label={i18n._(/* i18n*/ `Add to Cart`)}
     />
   )

--- a/packages/magento-product/components/AddProductsToCart/AddProductsToCartFab.tsx
+++ b/packages/magento-product/components/AddProductsToCart/AddProductsToCartFab.tsx
@@ -20,7 +20,7 @@ export function AddProductsToCartFab(props: AddProductsToCartFabProps) {
       type='submit'
       {...rest}
       {...action}
-      icon={action.showSuccess ? iconCheckmark : icon}
+      icon={action.showSuccess && !action.loading ? iconCheckmark : icon}
       aria-label={i18n._(/* i18n*/ `Add to Cart`)}
     />
   )

--- a/packages/magento-product/components/AddProductsToCart/AddProductsToCartFab.tsx
+++ b/packages/magento-product/components/AddProductsToCart/AddProductsToCartFab.tsx
@@ -14,13 +14,14 @@ export type AddProductsToCartFabProps = {
 
 export function AddProductsToCartFab(props: AddProductsToCartFabProps) {
   const { icon = iconShoppingBag, product, sku, ...rest } = props
-  const action = useAddProductsToCartAction(props)
+  const { showSuccess, ...action } = useAddProductsToCartAction(props)
+
   return (
     <Fab
       type='submit'
       {...rest}
       {...action}
-      icon={action.showSuccess && !action.loading ? iconCheckmark : icon}
+      icon={showSuccess && !action.loading ? iconCheckmark : icon}
       aria-label={i18n._(/* i18n*/ `Add to Cart`)}
     />
   )

--- a/packages/magento-product/components/AddProductsToCart/AddProductsToCartForm.tsx
+++ b/packages/magento-product/components/AddProductsToCart/AddProductsToCartForm.tsx
@@ -61,7 +61,7 @@ export function AddProductsToCartForm(props: AddProductsToCartFormProps) {
     redirect,
     onComplete,
     sx,
-    disableSnackbar,
+    disableSuccessSnackbar,
     errorSnackbar,
     successSnackbar,
     ...formProps
@@ -143,7 +143,7 @@ export function AddProductsToCartForm(props: AddProductsToCartFormProps) {
       <AddProductsToCartSnackbar
         errorSnackbar={errorSnackbar}
         successSnackbar={successSnackbar}
-        disableSnackbar={disableSnackbar}
+        disableSuccessSnackbar={disableSuccessSnackbar}
       />
     </AddProductsToCartContext.Provider>
   )

--- a/packages/magento-product/components/AddProductsToCart/AddProductsToCartForm.tsx
+++ b/packages/magento-product/components/AddProductsToCart/AddProductsToCartForm.tsx
@@ -8,7 +8,7 @@ import {
 import { ExtendableComponent } from '@graphcommerce/next-ui'
 import { Box, SxProps, Theme, useThemeProps } from '@mui/material'
 import { useRouter } from 'next/router'
-import { useEffect, useMemo, useRef } from 'react'
+import { useMemo, useRef } from 'react'
 import {
   AddProductsToCartDocument,
   AddProductsToCartMutation,

--- a/packages/magento-product/components/AddProductsToCart/AddProductsToCartForm.tsx
+++ b/packages/magento-product/components/AddProductsToCart/AddProductsToCartForm.tsx
@@ -8,7 +8,7 @@ import {
 import { ExtendableComponent } from '@graphcommerce/next-ui'
 import { Box, SxProps, Theme, useThemeProps } from '@mui/material'
 import { useRouter } from 'next/router'
-import { useMemo, useRef } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import {
   AddProductsToCartDocument,
   AddProductsToCartMutation,
@@ -56,8 +56,16 @@ declare module '@mui/material/styles/components' {
  * - Redirects the user to the cart/checkout/added page after successful submission.
  */
 export function AddProductsToCartForm(props: AddProductsToCartFormProps) {
-  let { children, redirect, onComplete, sx, errorSnackbar, successSnackbar, ...formProps } =
-    useThemeProps({ name, props })
+  let {
+    children,
+    redirect,
+    onComplete,
+    sx,
+    disabledSnackbar,
+    errorSnackbar,
+    successSnackbar,
+    ...formProps
+  } = useThemeProps({ name, props })
   const router = useRouter()
   const client = useApolloClient()
   const crosssellsQuery = useRef<Promise<ApolloQueryResult<CrosssellsQuery>>>()
@@ -132,7 +140,11 @@ export function AddProductsToCartForm(props: AddProductsToCartFormProps) {
       <Box component='form' onSubmit={submit} noValidate sx={sx} className={name}>
         {children}
       </Box>
-      <AddProductsToCartSnackbar errorSnackbar={errorSnackbar} successSnackbar={successSnackbar} />
+      <AddProductsToCartSnackbar
+        errorSnackbar={errorSnackbar}
+        successSnackbar={successSnackbar}
+        disabledSnackbar={disabledSnackbar}
+      />
     </AddProductsToCartContext.Provider>
   )
 }

--- a/packages/magento-product/components/AddProductsToCart/AddProductsToCartForm.tsx
+++ b/packages/magento-product/components/AddProductsToCart/AddProductsToCartForm.tsx
@@ -29,6 +29,8 @@ export type AddProductsToCartFormProps = {
   sx?: SxProps<Theme>
   // eslint-disable-next-line react/no-unused-prop-types
   redirect?: RedirectType
+
+  disableSuccessSnackbar?: boolean
 } & UseFormGraphQlOptions<AddProductsToCartMutation, AddProductsToCartMutationVariables> &
   AddProductsToCartSnackbarProps
 
@@ -140,11 +142,12 @@ export function AddProductsToCartForm(props: AddProductsToCartFormProps) {
       <Box component='form' onSubmit={submit} noValidate sx={sx} className={name}>
         {children}
       </Box>
-      <AddProductsToCartSnackbar
-        errorSnackbar={errorSnackbar}
-        successSnackbar={successSnackbar}
-        disableSuccessSnackbar={disableSuccessSnackbar}
-      />
+      {disableSuccessSnackbar ? null : (
+        <AddProductsToCartSnackbar
+          errorSnackbar={errorSnackbar}
+          successSnackbar={successSnackbar}
+        />
+      )}
     </AddProductsToCartContext.Provider>
   )
 }

--- a/packages/magento-product/components/AddProductsToCart/AddProductsToCartForm.tsx
+++ b/packages/magento-product/components/AddProductsToCart/AddProductsToCartForm.tsx
@@ -61,7 +61,7 @@ export function AddProductsToCartForm(props: AddProductsToCartFormProps) {
     redirect,
     onComplete,
     sx,
-    disabledSnackbar,
+    disableSnackbar,
     errorSnackbar,
     successSnackbar,
     ...formProps
@@ -143,7 +143,7 @@ export function AddProductsToCartForm(props: AddProductsToCartFormProps) {
       <AddProductsToCartSnackbar
         errorSnackbar={errorSnackbar}
         successSnackbar={successSnackbar}
-        disabledSnackbar={disabledSnackbar}
+        disableSnackbar={disableSnackbar}
       />
     </AddProductsToCartContext.Provider>
   )

--- a/packages/magento-product/components/AddProductsToCart/AddProductsToCartSnackbar.tsx
+++ b/packages/magento-product/components/AddProductsToCart/AddProductsToCartSnackbar.tsx
@@ -17,10 +17,11 @@ import { useFormAddProductsToCart } from './useFormAddProductsToCart'
 export type AddProductsToCartSnackbarProps = {
   errorSnackbar?: Omit<ErrorSnackbarProps, 'open'>
   successSnackbar?: Omit<MessageSnackbarProps, 'open' | 'action'>
+  disabledSnackbar?: boolean
 }
 
 export function AddProductsToCartSnackbar(props: AddProductsToCartSnackbarProps) {
-  const { errorSnackbar, successSnackbar } = props
+  const { errorSnackbar, successSnackbar, disabledSnackbar } = props
   const { error, data, redirect, control } = useFormAddProductsToCart()
   const formState = useFormState({ control })
 
@@ -36,6 +37,8 @@ export function AddProductsToCartSnackbar(props: AddProductsToCartSnackbarProps)
   const items = filterNonNullableKeys(data?.addProductsToCart?.cart.items)
 
   const showErrorSnackbar = userErrors.length > 0
+
+  if (disabledSnackbar) return null
 
   return (
     <>

--- a/packages/magento-product/components/AddProductsToCart/AddProductsToCartSnackbar.tsx
+++ b/packages/magento-product/components/AddProductsToCart/AddProductsToCartSnackbar.tsx
@@ -78,7 +78,11 @@ export function AddProductsToCartSnackbar(props: AddProductsToCartSnackbarProps)
           }
         >
           <Trans
-            id='<0>{name}</0> has been added to your shopping cart!'
+            id={
+              productsAdded.length === 1
+                ? '<0>{name}</0> has been added to your shopping cart!'
+                : '<0>{name}</0> have been added to your shopping cart!'
+            }
             components={{ 0: <strong /> }}
             values={{
               name: formatter.format(productsAdded),

--- a/packages/magento-product/components/AddProductsToCart/AddProductsToCartSnackbar.tsx
+++ b/packages/magento-product/components/AddProductsToCart/AddProductsToCartSnackbar.tsx
@@ -36,14 +36,10 @@ export function AddProductsToCartSnackbar(props: AddProductsToCartSnackbarProps)
 
   const items = filterNonNullableKeys(data?.addProductsToCart?.cart.items)
 
-  const productSkus: (string | undefined | null)[] = []
-
-  submittedVariables?.cartItems.forEach((item) => {
-    productSkus.push(item.sku)
-  })
-
   const productsAdded = items
-    .filter((item) => productSkus.includes(item.product.sku))
+    .filter((item) =>
+      submittedVariables?.cartItems?.find((cartItem) => cartItem.sku === item.product.sku),
+    )
     .map((product) => product.product.name)
 
   const showErrorSnackbar = userErrors.length > 0

--- a/packages/magento-product/components/AddProductsToCart/AddProductsToCartSnackbar.tsx
+++ b/packages/magento-product/components/AddProductsToCart/AddProductsToCartSnackbar.tsx
@@ -18,11 +18,10 @@ import { useFormAddProductsToCart } from './useFormAddProductsToCart'
 export type AddProductsToCartSnackbarProps = {
   errorSnackbar?: Omit<ErrorSnackbarProps, 'open'>
   successSnackbar?: Omit<MessageSnackbarProps, 'open' | 'action'>
-  disableSuccessSnackbar?: boolean
 }
 
 export function AddProductsToCartSnackbar(props: AddProductsToCartSnackbarProps) {
-  const { errorSnackbar, successSnackbar, disableSuccessSnackbar } = props
+  const { errorSnackbar, successSnackbar } = props
   const { error, data, redirect, control, submittedVariables } = useFormAddProductsToCart()
   const formState = useFormState({ control })
   const { locale } = useRouter()
@@ -41,8 +40,9 @@ export function AddProductsToCartSnackbar(props: AddProductsToCartSnackbarProps)
   const items = filterNonNullableKeys(data?.addProductsToCart?.cart.items)
 
   const productsAdded = items
-    .filter((item) =>
-      submittedVariables?.cartItems?.find((cartItem) => cartItem.sku === item.product.sku),
+    .filter(
+      (item) =>
+        submittedVariables?.cartItems?.find((cartItem) => cartItem.sku === item.product.sku),
     )
     .map((product) => product.product.name || '')
 

--- a/packages/magento-product/components/AddProductsToCart/AddProductsToCartSnackbar.tsx
+++ b/packages/magento-product/components/AddProductsToCart/AddProductsToCartSnackbar.tsx
@@ -17,11 +17,11 @@ import { useFormAddProductsToCart } from './useFormAddProductsToCart'
 export type AddProductsToCartSnackbarProps = {
   errorSnackbar?: Omit<ErrorSnackbarProps, 'open'>
   successSnackbar?: Omit<MessageSnackbarProps, 'open' | 'action'>
-  disableSnackbar?: boolean
+  disableSuccessSnackbar?: boolean
 }
 
 export function AddProductsToCartSnackbar(props: AddProductsToCartSnackbarProps) {
-  const { errorSnackbar, successSnackbar, disableSnackbar } = props
+  const { errorSnackbar, successSnackbar, disableSuccessSnackbar } = props
   const { error, data, redirect, control, submittedVariables } = useFormAddProductsToCart()
   const formState = useFormState({ control })
 
@@ -48,8 +48,6 @@ export function AddProductsToCartSnackbar(props: AddProductsToCartSnackbarProps)
 
   const showErrorSnackbar = userErrors.length > 0
 
-  if (disableSnackbar) return null
-
   return (
     <>
       {error && <ApolloCartErrorSnackbar error={error} />}
@@ -60,7 +58,7 @@ export function AddProductsToCartSnackbar(props: AddProductsToCartSnackbarProps)
         </ErrorSnackbar>
       )}
 
-      {showSuccess && (
+      {showSuccess && !disableSuccessSnackbar && (
         <MessageSnackbar
           variant='pill'
           {...successSnackbar}

--- a/packages/magento-product/components/AddProductsToCart/AddProductsToCartSnackbar.tsx
+++ b/packages/magento-product/components/AddProductsToCart/AddProductsToCartSnackbar.tsx
@@ -17,12 +17,12 @@ import { useFormAddProductsToCart } from './useFormAddProductsToCart'
 export type AddProductsToCartSnackbarProps = {
   errorSnackbar?: Omit<ErrorSnackbarProps, 'open'>
   successSnackbar?: Omit<MessageSnackbarProps, 'open' | 'action'>
-  disabledSnackbar?: boolean
+  disableSnackbar?: boolean
 }
 
 export function AddProductsToCartSnackbar(props: AddProductsToCartSnackbarProps) {
-  const { errorSnackbar, successSnackbar, disabledSnackbar } = props
-  const { error, data, redirect, control } = useFormAddProductsToCart()
+  const { errorSnackbar, successSnackbar, disableSnackbar } = props
+  const { error, data, redirect, control, submittedVariables } = useFormAddProductsToCart()
   const formState = useFormState({ control })
 
   const userErrors = toUserErrors(data)
@@ -36,9 +36,19 @@ export function AddProductsToCartSnackbar(props: AddProductsToCartSnackbarProps)
 
   const items = filterNonNullableKeys(data?.addProductsToCart?.cart.items)
 
+  const productSkus: (string | undefined | null)[] = []
+
+  submittedVariables?.cartItems.forEach((item) => {
+    productSkus.push(item.sku)
+  })
+
+  const productsAdded = items
+    .filter((item) => productSkus.includes(item.product.sku))
+    .map((product) => product.product.name)
+
   const showErrorSnackbar = userErrors.length > 0
 
-  if (disabledSnackbar) return null
+  if (disableSnackbar) return null
 
   return (
     <>
@@ -72,7 +82,7 @@ export function AddProductsToCartSnackbar(props: AddProductsToCartSnackbarProps)
           <Trans
             id='<0>{name}</0> has been added to your shopping cart!'
             components={{ 0: <strong /> }}
-            values={{ name: items[items.length - 1]?.product.name }}
+            values={{ name: productsAdded.join(', ') }}
           />
         </MessageSnackbar>
       )}

--- a/packages/magento-product/components/AddProductsToCart/AddProductsToCartSnackbar.tsx
+++ b/packages/magento-product/components/AddProductsToCart/AddProductsToCartSnackbar.tsx
@@ -11,6 +11,7 @@ import {
   MessageSnackbarProps,
 } from '@graphcommerce/next-ui'
 import { Trans } from '@lingui/react'
+import { useRouter } from 'next/router'
 import { toUserErrors } from './toUserErrors'
 import { useFormAddProductsToCart } from './useFormAddProductsToCart'
 
@@ -24,6 +25,9 @@ export function AddProductsToCartSnackbar(props: AddProductsToCartSnackbarProps)
   const { errorSnackbar, successSnackbar, disableSuccessSnackbar } = props
   const { error, data, redirect, control, submittedVariables } = useFormAddProductsToCart()
   const formState = useFormState({ control })
+  const { locale } = useRouter()
+
+  const formatter = new Intl.ListFormat(locale, { style: 'long', type: 'conjunction' })
 
   const userErrors = toUserErrors(data)
 
@@ -40,7 +44,7 @@ export function AddProductsToCartSnackbar(props: AddProductsToCartSnackbarProps)
     .filter((item) =>
       submittedVariables?.cartItems?.find((cartItem) => cartItem.sku === item.product.sku),
     )
-    .map((product) => product.product.name)
+    .map((product) => product.product.name || '')
 
   const showErrorSnackbar = userErrors.length > 0
 
@@ -76,7 +80,9 @@ export function AddProductsToCartSnackbar(props: AddProductsToCartSnackbarProps)
           <Trans
             id='<0>{name}</0> has been added to your shopping cart!'
             components={{ 0: <strong /> }}
-            values={{ name: productsAdded.join(', ') }}
+            values={{
+              name: formatter.format(productsAdded),
+            }}
           />
         </MessageSnackbar>
       )}

--- a/packages/magento-product/components/AddProductsToCart/AddProductsToCartSnackbar.tsx
+++ b/packages/magento-product/components/AddProductsToCart/AddProductsToCartSnackbar.tsx
@@ -58,7 +58,7 @@ export function AddProductsToCartSnackbar(props: AddProductsToCartSnackbarProps)
         </ErrorSnackbar>
       )}
 
-      {showSuccess && !disableSuccessSnackbar && (
+      {showSuccess && (
         <MessageSnackbar
           variant='pill'
           {...successSnackbar}

--- a/packages/magento-product/components/AddProductsToCart/useAddProductsToCartAction.ts
+++ b/packages/magento-product/components/AddProductsToCart/useAddProductsToCartAction.ts
@@ -49,13 +49,11 @@ export function useAddProductsToCartAction(
     }
   }, [sku, submitSuccesful, submittedVariables?.cartItems])
 
-  useEffect(() => {
-    if (showSuccess) {
-      setTimeout(() => {
-        setShowSuccess(false)
-      }, 2000)
-    }
-  }, [showSuccess])
+  if (showSuccess) {
+    setTimeout(() => {
+      setShowSuccess(false)
+    }, 2000)
+  }
 
   useEffect(() => {
     console.log('SubmitSuccesful: ', submitSuccesful)

--- a/packages/magento-product/components/AddProductsToCart/useAddProductsToCartAction.ts
+++ b/packages/magento-product/components/AddProductsToCart/useAddProductsToCartAction.ts
@@ -55,9 +55,11 @@ export function useAddProductsToCartAction(
   }
 
   useEffect(() => {
-    setTimeout(() => {
-      setShowSuccess(false)
-    }, 2000)
+    if (showSuccess) {
+      setTimeout(() => {
+        setShowSuccess(false)
+      }, 2000)
+    }
   }, [showSuccess])
 
   useEffect(() => {

--- a/packages/magento-product/components/AddProductsToCart/useAddProductsToCartAction.ts
+++ b/packages/magento-product/components/AddProductsToCart/useAddProductsToCartAction.ts
@@ -46,16 +46,20 @@ export function useAddProductsToCartAction(
 
   useEffect(() => {
     if (submitSuccesful && submittedVariables?.cartItems.find((item) => item.sku === sku)) {
-      if (timer.current) clearTimeout(timer.current)
       setShowSuccess(true)
     }
   }, [sku, submitSuccesful, submittedVariables?.cartItems])
 
-  if (showSuccess) {
-    timer.current = setTimeout(() => {
-      setShowSuccess(false)
-    }, 2000)
-  }
+  useEffect(() => {
+    if (showSuccess) {
+      timer.current = setTimeout(() => {
+        setShowSuccess(false)
+      }, 2000)
+    }
+    return () => {
+      if (timer.current) clearTimeout(timer.current)
+    }
+  }, [showSuccess])
 
   return {
     disabled:

--- a/packages/magento-product/components/AddProductsToCart/useAddProductsToCartAction.ts
+++ b/packages/magento-product/components/AddProductsToCart/useAddProductsToCartAction.ts
@@ -43,25 +43,17 @@ export function useAddProductsToCartAction(
   const submitSuccesful =
     !formState.isSubmitting && formState.isSubmitSuccessful && !error?.message && !userErrors.length
 
-  const [prevSubmitSuccessful, setPrevSubmitSuccessful] = useState<boolean>(submitSuccesful)
-  if (
-    submitSuccesful !== prevSubmitSuccessful &&
-    submitSuccesful &&
-    submittedVariables?.cartItems.find((item) => item.sku === sku)
-  ) {
-    setPrevSubmitSuccessful(submitSuccesful)
-    setShowSuccess(true)
-  }
+  useEffect(() => {
+    if (submitSuccesful && submittedVariables?.cartItems.find((item) => item.sku === sku)) {
+      setShowSuccess(true)
+    }
+  }, [sku, submitSuccesful, submittedVariables?.cartItems])
 
   if (showSuccess) {
     setTimeout(() => {
       setShowSuccess(false)
     }, 2000)
   }
-
-  useEffect(() => {
-    console.log('SubmitSuccesful: ', submitSuccesful)
-  }, [submitSuccesful])
 
   return {
     disabled:

--- a/packages/magento-product/components/AddProductsToCart/useAddProductsToCartAction.ts
+++ b/packages/magento-product/components/AddProductsToCart/useAddProductsToCartAction.ts
@@ -36,7 +36,6 @@ export function useAddProductsToCartAction(
     loading,
   } = props
 
-  const timer = useRef<null | ReturnType<typeof setTimeout>>()
   const [showSuccess, setShowSuccess] = useState<boolean>(false)
 
   const userErrors = toUserErrors(data)
@@ -51,13 +50,14 @@ export function useAddProductsToCartAction(
   }, [sku, submitSuccesful, submittedVariables?.cartItems])
 
   useEffect(() => {
+    let timer: ReturnType<typeof setTimeout>
     if (showSuccess) {
-      timer.current = setTimeout(() => {
+      timer = setTimeout(() => {
         setShowSuccess(false)
       }, 2000)
     }
     return () => {
-      if (timer.current) clearTimeout(timer.current)
+      clearTimeout(timer)
     }
   }, [showSuccess])
 

--- a/packages/magento-product/components/AddProductsToCart/useAddProductsToCartAction.ts
+++ b/packages/magento-product/components/AddProductsToCart/useAddProductsToCartAction.ts
@@ -1,6 +1,6 @@
 import { useFormState } from '@graphcommerce/ecommerce-ui'
 import { useEventCallback } from '@mui/material'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { UseAddProductsToCartActionFragment } from './UseAddProductsToCartAction.gql'
 import { toUserErrors } from './toUserErrors'
 import { AddToCartItemSelector, useFormAddProductsToCart } from './useFormAddProductsToCart'
@@ -27,14 +27,9 @@ export function useAddProductsToCartAction(
   const { setValue, getValues, control, error, data, submittedVariables } =
     useFormAddProductsToCart()
   const formState = useFormState({ control })
-  const {
-    sku = props.product?.sku,
-    product,
-    index = 0,
-    onClick: onClickIncoming,
-    disabled,
-    loading,
-  } = props
+  const { sku = props.product?.sku, product, index = 0, onClick: onClickIncoming, disabled } = props
+
+  const loading = formState.isSubmitting && getValues(`cartItems.${index}.sku`) === sku
 
   const [showSuccess, setShowSuccess] = useState<boolean>(false)
 
@@ -51,6 +46,7 @@ export function useAddProductsToCartAction(
 
   useEffect(() => {
     let timer: ReturnType<typeof setTimeout>
+
     if (showSuccess) {
       timer = setTimeout(() => {
         setShowSuccess(false)
@@ -59,13 +55,13 @@ export function useAddProductsToCartAction(
     return () => {
       clearTimeout(timer)
     }
-  }, [showSuccess])
+  }, [showSuccess, loading])
 
   return {
     disabled:
       product?.stock_status === 'OUT_OF_STOCK' ||
       Boolean(formState.errors.cartItems?.[index]?.sku?.message || disabled),
-    loading: loading || (formState.isSubmitting && getValues(`cartItems.${index}.sku`) === sku),
+    loading,
     onClick: useEventCallback((e) => {
       e.stopPropagation()
       if (formState.isSubmitting) return

--- a/packages/magento-product/components/AddProductsToCart/useAddProductsToCartAction.ts
+++ b/packages/magento-product/components/AddProductsToCart/useAddProductsToCartAction.ts
@@ -24,7 +24,7 @@ export type UseAddProductsToCartActionReturn = {
 export function useAddProductsToCartAction(
   props: UseAddProductsToCartActionProps,
 ): UseAddProductsToCartActionReturn {
-  const { setValue, getValues, control, error, data, redirect, submittedVariables } =
+  const { setValue, getValues, control, error, data, submittedVariables } =
     useFormAddProductsToCart()
   const formState = useFormState({ control })
   const {
@@ -41,11 +41,7 @@ export function useAddProductsToCartAction(
   const userErrors = toUserErrors(data)
 
   const submitSuccesful =
-    !formState.isSubmitting &&
-    formState.isSubmitSuccessful &&
-    !error?.message &&
-    !userErrors.length &&
-    !redirect
+    !formState.isSubmitting && formState.isSubmitSuccessful && !error?.message && !userErrors.length
 
   useEffect(() => {
     if (submitSuccesful && submittedVariables?.cartItems.find((item) => item.sku === sku)) {

--- a/packages/magento-product/components/AddProductsToCart/useAddProductsToCartAction.ts
+++ b/packages/magento-product/components/AddProductsToCart/useAddProductsToCartAction.ts
@@ -44,6 +44,7 @@ export function useAddProductsToCartAction(
     !formState.isSubmitting && formState.isSubmitSuccessful && !error?.message && !userErrors.length
 
   const [prevSubmitSuccessful, setPrevSubmitSuccessful] = useState<boolean>(submitSuccesful)
+
   if (
     submitSuccesful !== prevSubmitSuccessful &&
     submitSuccesful &&
@@ -56,8 +57,13 @@ export function useAddProductsToCartAction(
   if (showSuccess) {
     setTimeout(() => {
       setShowSuccess(false)
+      setPrevSubmitSuccessful(false)
     }, 2000)
   }
+
+  useEffect(() => {
+    console.log('SubmitSuccesful: ', submitSuccesful)
+  }, [submitSuccesful])
 
   return {
     disabled:

--- a/packages/magento-product/components/AddProductsToCart/useAddProductsToCartAction.ts
+++ b/packages/magento-product/components/AddProductsToCart/useAddProductsToCartAction.ts
@@ -54,12 +54,11 @@ export function useAddProductsToCartAction(
     setShowSuccess(true)
   }
 
-  if (showSuccess) {
+  useEffect(() => {
     setTimeout(() => {
       setShowSuccess(false)
-      setPrevSubmitSuccessful(false)
     }, 2000)
-  }
+  }, [showSuccess])
 
   useEffect(() => {
     console.log('SubmitSuccesful: ', submitSuccesful)

--- a/packages/magento-product/components/AddProductsToCart/useAddProductsToCartAction.ts
+++ b/packages/magento-product/components/AddProductsToCart/useAddProductsToCartAction.ts
@@ -1,6 +1,6 @@
 import { useFormState } from '@graphcommerce/ecommerce-ui'
 import { useEventCallback } from '@mui/material'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { UseAddProductsToCartActionFragment } from './UseAddProductsToCartAction.gql'
 import { toUserErrors } from './toUserErrors'
 import { AddToCartItemSelector, useFormAddProductsToCart } from './useFormAddProductsToCart'
@@ -36,6 +36,7 @@ export function useAddProductsToCartAction(
     loading,
   } = props
 
+  const timer = useRef<null | ReturnType<typeof setTimeout>>()
   const [showSuccess, setShowSuccess] = useState<boolean>(false)
 
   const userErrors = toUserErrors(data)
@@ -45,12 +46,13 @@ export function useAddProductsToCartAction(
 
   useEffect(() => {
     if (submitSuccesful && submittedVariables?.cartItems.find((item) => item.sku === sku)) {
+      if (timer.current) clearTimeout(timer.current)
       setShowSuccess(true)
     }
   }, [sku, submitSuccesful, submittedVariables?.cartItems])
 
   if (showSuccess) {
-    setTimeout(() => {
+    timer.current = setTimeout(() => {
       setShowSuccess(false)
     }, 2000)
   }

--- a/packages/magento-product/components/AddProductsToCart/useAddProductsToCartAction.ts
+++ b/packages/magento-product/components/AddProductsToCart/useAddProductsToCartAction.ts
@@ -43,11 +43,15 @@ export function useAddProductsToCartAction(
   const submitSuccesful =
     !formState.isSubmitting && formState.isSubmitSuccessful && !error?.message && !userErrors.length
 
-  useEffect(() => {
-    if (submitSuccesful && submittedVariables?.cartItems.find((item) => item.sku === sku)) {
-      setShowSuccess(true)
-    }
-  }, [sku, submitSuccesful, submittedVariables?.cartItems])
+  const [prevSubmitSuccessful, setPrevSubmitSuccessful] = useState<boolean>(submitSuccesful)
+  if (
+    submitSuccesful !== prevSubmitSuccessful &&
+    submitSuccesful &&
+    submittedVariables?.cartItems.find((item) => item.sku === sku)
+  ) {
+    setPrevSubmitSuccessful(submitSuccesful)
+    setShowSuccess(true)
+  }
 
   if (showSuccess) {
     setTimeout(() => {

--- a/packages/magento-product/components/AddProductsToCart/useAddProductsToCartAction.ts
+++ b/packages/magento-product/components/AddProductsToCart/useAddProductsToCartAction.ts
@@ -43,19 +43,21 @@ export function useAddProductsToCartAction(
   const submitSuccesful =
     !formState.isSubmitting && formState.isSubmitSuccessful && !error?.message && !userErrors.length
 
-  useEffect(() => {
-    if (submitSuccesful && submittedVariables?.cartItems.find((item) => item.sku === sku)) {
-      setShowSuccess(true)
-    }
-  }, [sku, submitSuccesful, submittedVariables?.cartItems])
+  const [prevSubmitSuccessful, setPrevSubmitSuccessful] = useState<boolean>(submitSuccesful)
+  if (
+    submitSuccesful !== prevSubmitSuccessful &&
+    submitSuccesful &&
+    submittedVariables?.cartItems.find((item) => item.sku === sku)
+  ) {
+    setPrevSubmitSuccessful(submitSuccesful)
+    setShowSuccess(true)
+  }
 
-  useEffect(() => {
-    if (showSuccess) {
-      setTimeout(() => {
-        setShowSuccess(false)
-      }, 2000)
-    }
-  }, [showSuccess])
+  if (showSuccess) {
+    setTimeout(() => {
+      setShowSuccess(false)
+    }, 2000)
+  }
 
   return {
     disabled:

--- a/packages/magento-product/components/AddProductsToCart/useAddProductsToCartAction.ts
+++ b/packages/magento-product/components/AddProductsToCart/useAddProductsToCartAction.ts
@@ -43,16 +43,11 @@ export function useAddProductsToCartAction(
   const submitSuccesful =
     !formState.isSubmitting && formState.isSubmitSuccessful && !error?.message && !userErrors.length
 
-  const [prevSubmitSuccessful, setPrevSubmitSuccessful] = useState<boolean>(submitSuccesful)
-
-  if (
-    submitSuccesful !== prevSubmitSuccessful &&
-    submitSuccesful &&
-    submittedVariables?.cartItems.find((item) => item.sku === sku)
-  ) {
-    setPrevSubmitSuccessful(submitSuccesful)
-    setShowSuccess(true)
-  }
+  useEffect(() => {
+    if (submitSuccesful && submittedVariables?.cartItems.find((item) => item.sku === sku)) {
+      setShowSuccess(true)
+    }
+  }, [sku, submitSuccesful, submittedVariables?.cartItems])
 
   useEffect(() => {
     if (showSuccess) {

--- a/packages/magento-product/components/AddProductsToCart/useAddProductsToCartAction.ts
+++ b/packages/magento-product/components/AddProductsToCart/useAddProductsToCartAction.ts
@@ -1,6 +1,8 @@
 import { useFormState } from '@graphcommerce/ecommerce-ui'
 import { useEventCallback } from '@mui/material'
+import { useEffect, useState } from 'react'
 import { UseAddProductsToCartActionFragment } from './UseAddProductsToCartAction.gql'
+import { toUserErrors } from './toUserErrors'
 import { AddToCartItemSelector, useFormAddProductsToCart } from './useFormAddProductsToCart'
 
 export type UseAddProductsToCartActionProps = AddToCartItemSelector & {
@@ -16,12 +18,14 @@ export type UseAddProductsToCartActionReturn = {
   loading: boolean
   onClick: React.MouseEventHandler<HTMLButtonElement>
   onMouseDown: React.MouseEventHandler<HTMLButtonElement>
+  showSuccess: boolean
 }
 
 export function useAddProductsToCartAction(
   props: UseAddProductsToCartActionProps,
 ): UseAddProductsToCartActionReturn {
-  const { setValue, getValues, control } = useFormAddProductsToCart()
+  const { setValue, getValues, control, error, data, redirect, submittedVariables } =
+    useFormAddProductsToCart()
   const formState = useFormState({ control })
   const {
     sku = props.product?.sku,
@@ -31,6 +35,31 @@ export function useAddProductsToCartAction(
     disabled,
     loading,
   } = props
+
+  const [showSuccess, setShowSuccess] = useState<boolean>(false)
+
+  const userErrors = toUserErrors(data)
+
+  const submitSuccesful =
+    !formState.isSubmitting &&
+    formState.isSubmitSuccessful &&
+    !error?.message &&
+    !userErrors.length &&
+    !redirect
+
+  useEffect(() => {
+    if (submitSuccesful && submittedVariables?.cartItems.find((item) => item.sku === sku)) {
+      setShowSuccess(true)
+    }
+  }, [sku, submitSuccesful, submittedVariables?.cartItems])
+
+  useEffect(() => {
+    if (showSuccess) {
+      setTimeout(() => {
+        setShowSuccess(false)
+      }, 2000)
+    }
+  }, [showSuccess])
 
   return {
     disabled:
@@ -47,5 +76,6 @@ export function useAddProductsToCartAction(
       onClickIncoming?.(e)
     }),
     onMouseDown: useEventCallback((e) => e.stopPropagation()),
+    showSuccess,
   }
 }

--- a/packages/react-hook-form/src/useFormGql.tsx
+++ b/packages/react-hook-form/src/useFormGql.tsx
@@ -70,6 +70,7 @@ export function useFormGql<Q, V extends FieldValues>(
   const handleSubmit: UseFormReturn<V>['handleSubmit'] = (onValid, onInvalid) =>
     form.handleSubmit(async (formValues, event) => {
       // Combine defaults with the formValues and encode
+      submittedVariables.current = undefined
       let variables = encode({ ...defaultValues, ...formValues })
 
       // Wait for the onBeforeSubmit to complete

--- a/packages/react-hook-form/src/useFormGql.tsx
+++ b/packages/react-hook-form/src/useFormGql.tsx
@@ -28,9 +28,7 @@ export type UseFormGqlMethods<Q, V extends FieldValues> = Omit<
   UseGqlDocumentHandler<V>,
   'encode' | 'type'
 > &
-  Pick<UseFormReturn<V>, 'handleSubmit'> & { data?: Q | null; error?: ApolloError } & {
-    submittedVariables?: V
-  }
+  Pick<UseFormReturn<V>, 'handleSubmit'> & { data?: Q | null; error?: ApolloError; submittedVariables?: V }
 
 /**
  * Combines useMutation/useLazyQuery with react-hook-form's useForm:

--- a/packagesDev/next-config/dist/generated/config.js
+++ b/packagesDev/next-config/dist/generated/config.js
@@ -53,6 +53,8 @@ function GraphCommerceConfigSchema() {
         compareVariant: CompareVariantSchema.nullish(),
         configurableVariantForSimple: _zod.z.boolean().nullish(),
         configurableVariantValues: MagentoConfigurableVariantValuesSchema().nullish(),
+        crossSellsHideCartItems: _zod.z.boolean().nullish(),
+        crossSellsRedirectItems: _zod.z.boolean().nullish(),
         customerRequireEmailConfirmation: _zod.z.boolean().nullish(),
         debug: GraphCommerceDebugConfigSchema().nullish(),
         demoMode: _zod.z.boolean().nullish(),

--- a/packagesDev/next-config/src/generated/config.ts
+++ b/packagesDev/next-config/src/generated/config.ts
@@ -140,6 +140,18 @@ export type GraphCommerceConfig = {
    */
   configurableVariantValues?: InputMaybe<MagentoConfigurableVariantValues>;
   /**
+   * Determines if cross sell items should be shown when the user already has the product in their cart. This will result in a product will popping off the screen when you add it to the cart.
+   *
+   * Default: 'false'
+   */
+  crossSellsHideCartItems?: InputMaybe<Scalars['Boolean']['input']>;
+  /**
+   * Determines if, after adding a cross-sell item to the cart, the user should be redirected to the cross-sell items of the product they just added.
+   *
+   * Default: 'false'
+   */
+  crossSellsRedirectItems?: InputMaybe<Scalars['Boolean']['input']>;
+  /**
    * Due to a limitation in the GraphQL API of Magento 2, we need to know if the
    * customer requires email confirmation.
    *
@@ -395,6 +407,8 @@ export function GraphCommerceConfigSchema(): z.ZodObject<Properties<GraphCommerc
     compareVariant: CompareVariantSchema.nullish(),
     configurableVariantForSimple: z.boolean().nullish(),
     configurableVariantValues: MagentoConfigurableVariantValuesSchema().nullish(),
+    crossSellsHideCartItems: z.boolean().nullish(),
+    crossSellsRedirectItems: z.boolean().nullish(),
     customerRequireEmailConfirmation: z.boolean().nullish(),
     debug: GraphCommerceDebugConfigSchema().nullish(),
     demoMode: z.boolean().nullish(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -11790,7 +11790,7 @@ typescript@5.2.2, typescript@^5.0.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
   integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
 
-"uWebSockets.js@github:uNetworking/uWebSockets.js#semver:^20":
+"uWebSockets.js@uNetworking/uWebSockets.js#semver:^20":
   version "20.32.0"
   resolved "https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/21c0e41a662c27bcc29b64f3e9d7f0bdaa6d7ee7"
 


### PR DESCRIPTION
[In this ticket](https://hoproj.atlassian.net/browse/GCOM-1138) implemented a more desirable behavior of the related products, inspired by wishes from [KOM-442](https://hoproj.atlassian.net/browse/KOM-442)

first check: @bramvanderholst 
second check: @paales 


### Most important changes:

**Magento Product**
- Crosssells should remain visible after add to cart. Do not pop away.
- Checkmark icon after add to cart added. showSuccess prop based on snack bar.
- Redirect default behavior off
- Correct product name to snackbar message after add crosssell product.

- Configure whether we want to redirect?
- Configure whether we want to filter out products that are in your cart?

**React hook form**
- add onComplete to RHF 
- add SubmittedVariables to RHF 



**Test**
/p/fuzzy-sticky-things-gc-691-sock

[KOM-442]: https://hoproj.atlassian.net/browse/KOM-442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ