### PR TITLE
Decrease the fontSize for the payment button in the checkout to ensure the text fits within the button (GCOM-1186)

### DIFF
--- a/.changeset/real-garlics-battle.md
+++ b/.changeset/real-garlics-battle.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/magento-cart-payment-method': patch
+---
+
+decrease the fontSize for the payment button in the checkout to ensure the text fits within the button

--- a/.changeset/real-garlics-battle.md
+++ b/.changeset/real-garlics-battle.md
@@ -2,4 +2,4 @@
 '@graphcommerce/magento-cart-payment-method': patch
 ---
 
-decrease the fontSize for the payment button in the checkout to ensure the text fits within the button
+Remove the selected payment method title from the Place order button so that the text always fits

--- a/packages/magento-cart-payment-method/PaymentMethodButton/PaymentMethodButton.tsx
+++ b/packages/magento-cart-payment-method/PaymentMethodButton/PaymentMethodButton.tsx
@@ -27,6 +27,16 @@ function PaymentMethodButtonRenderer(
           {...buttonProps}
           onClick={submit}
           loading={buttonState.isSubmitting || (buttonState.isSubmitSuccessful && !error)}
+          button={{
+            sx: [
+              (theme) => ({
+                [theme.breakpoints.down('md')]: {
+                  fontSize: theme.typography.body2.fontSize,
+                },
+              }),
+            ],
+            ...buttonProps?.button,
+          }}
         >
           {buttonProps.children}
           {selectedMethod?.title && (

--- a/packages/magento-cart-payment-method/PaymentMethodButton/PaymentMethodButton.tsx
+++ b/packages/magento-cart-payment-method/PaymentMethodButton/PaymentMethodButton.tsx
@@ -27,24 +27,8 @@ function PaymentMethodButtonRenderer(
           {...buttonProps}
           onClick={submit}
           loading={buttonState.isSubmitting || (buttonState.isSubmitSuccessful && !error)}
-          button={{
-            sx: [
-              (theme) => ({
-                [theme.breakpoints.down('md')]: {
-                  fontSize: theme.typography.body2.fontSize,
-                },
-              }),
-            ],
-            ...buttonProps?.button,
-          }}
         >
           {buttonProps.children}
-          {selectedMethod?.title && (
-            <>
-              {' '}
-              (<em>{selectedMethod?.title}</em>)
-            </>
-          )}
         </LinkOrButton>
       ) : (
         <PaymentButton


### PR DESCRIPTION
| Before | After |
|--------|--------|
| ![localhost_3000_checkout_payment(iPhone 12 Pro) (1)](https://github.com/graphcommerce-org/graphcommerce/assets/62989724/f52c2127-2b60-444a-9e84-39d135384506) | ![localhost_3000_checkout_payment(iPhone 12 Pro) (2)](https://github.com/graphcommerce-org/graphcommerce/assets/62989724/b7c23d6f-3c2d-4ba2-9c16-84954722483b) |



