### PR TITLE
[GCOM-1230] configurableVariantForSimple fix

### DIFF
--- a/.changeset/healthy-spoons-doubt.md
+++ b/.changeset/healthy-spoons-doubt.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/magento-product-configurable': patch
+---
+
+Show simple when `configurableVariantForSimple = false` fix

--- a/.changeset/healthy-spoons-doubt.md
+++ b/.changeset/healthy-spoons-doubt.md
@@ -2,4 +2,4 @@
 '@graphcommerce/magento-product-configurable': patch
 ---
 
-Show simple when `configurableVariantForSimple = false` fix
+When configurableVariantForSimple was set to false it wouldn't correctly show the simple product.

--- a/packages/magento-product-configurable/utils/defaultConfigurableOptionsSelection.ts
+++ b/packages/magento-product-configurable/utils/defaultConfigurableOptionsSelection.ts
@@ -27,8 +27,10 @@ export function defaultConfigurableOptionsSelection<Q extends BaseQuery = BaseQu
   client: ApolloClient<object>,
   query: Q,
 ): Q & Pick<AddProductsToCartFormProps, 'defaultValues'> {
-  if (!import.meta.graphCommerce.configurableVariantForSimple)
-    return { ...query, defaultValues: {} }
+  if (!import.meta.graphCommerce.configurableVariantForSimple) {
+    const product = query?.products?.items?.find((p) => p?.url_key === urlKey)
+    return { ...query, products: { items: [product] }, defaultValues: {} }
+  }
 
   const simple = query?.products?.items?.find((p) => p?.url_key === urlKey)
   const configurable = findByTypename(query?.products?.items, 'ConfigurableProduct')
@@ -38,9 +40,8 @@ export function defaultConfigurableOptionsSelection<Q extends BaseQuery = BaseQu
     return { ...query, defaultValues: {} }
 
   // Find the requested simple product on the configurable variants and get the attributes.
-  const attributes = configurable?.variants?.find(
-    (v) => v?.product?.uid === simple?.uid,
-  )?.attributes
+  const attributes = configurable?.variants?.find((v) => v?.product?.uid === simple?.uid)
+    ?.attributes
 
   const selectedOptions = (attributes ?? []).filter(nonNullable).map((a) => a.uid)
   if (!selectedOptions.length) return { ...query, products: { items: [simple] }, defaultValues: {} }


### PR DESCRIPTION
When configurableVariantForSimple = false, show simple layout. This was done by modifying the products.items array that we only use the items that have the same urlKey as productpage

https://hoproj.atlassian.net/browse/GCOM-1230

## Summary

ConfigurableVariantForSimple = false still shows a configurable page on a simple

Canary

### Simple

[Backend](https://backend.reachdigital.dev/admin_1wwdkh/catalog/product/edit/id/45689/key/c6b8e37f9266cf6e3bfa44ed8adb9c3eed2230386698ea77952032f8ae594384/)

[Productpage](https://graphcommerce.vercel.app/p/super-squeaky-size-4-6y-gc-468-sock-6yp/spooky-girl-size-4-6y-gc-1-sock-6y)

### Configurable

[Backend](https://backend.reachdigital.dev/admin_1wwdkh/catalog/product/edit/id/45693/key/c6b8e37f9266cf6e3bfa44ed8adb9c3eed2230386698ea77952032f8ae594384/)

[Productpage](https://graphcommerce.vercel.app/p/super-squeaky-size-4-6y-gc-468-sock-6y)

