### PR TITLE
feat(GCOM-1190): add renderer to support rendering Hygraph elements with a CSS class

### DIFF
--- a/.changeset/little-shirts-film.md
+++ b/.changeset/little-shirts-film.md
@@ -1,0 +1,5 @@
+---
+"@graphcommerce/graphcms-ui": patch
+---
+
+feat(GCOM-1190): add renderer to support rendering Hygraph elements with a CSS class

--- a/packages/hygraph-ui/components/RichText/RichText.tsx
+++ b/packages/hygraph-ui/components/RichText/RichText.tsx
@@ -108,8 +108,18 @@ function RenderElement(element: ElementNode & AdditionalProps) {
 
   // todo: this has the any type, could be improved
   const Component: Renderer<SimpleElement> = renderers[type]
-
   const sx = useRenderProps({ first, last, sxRenderer }, type)
+
+  if (type === 'class') {
+    return (
+      <RenderChildren
+        className={props.className ?? ''}
+        childNodes={children}
+        sxRenderer={sxRenderer}
+        renderers={renderers}
+      />
+    )
+  }
 
   if (Component) {
     return (
@@ -171,12 +181,21 @@ export type RichTextProps = { raw: ElementNode } & {
   withMargin?: boolean
 }
 
+const hygraphClassRenderer = {
+  class: (props) => {
+    const RenderType = defaultRenderers[props.children.props.childNodes[0].type]
+    const { className, ...rest } = props
+
+    return <RenderType className={className} {...rest} />
+  },
+}
+
 export function RichText({ raw, sxRenderer, renderers, withMargin = false }: RichTextProps) {
   return (
     <RenderChildren
       childNodes={raw.children}
       sxRenderer={mergeSxRenderer(defaultSxRenderer, sxRenderer)}
-      renderers={{ ...defaultRenderers, ...renderers }}
+      renderers={{ ...defaultRenderers, ...hygraphClassRenderer, ...renderers }}
       noMargin={!withMargin}
     />
   )

--- a/packages/hygraph-ui/components/RichText/RichText.tsx
+++ b/packages/hygraph-ui/components/RichText/RichText.tsx
@@ -110,17 +110,6 @@ function RenderElement(element: ElementNode & AdditionalProps) {
   const Component: Renderer<SimpleElement> = renderers[type]
   const sx = useRenderProps({ first, last, sxRenderer }, type)
 
-  if (type === 'class') {
-    return (
-      <RenderChildren
-        className={props.className ?? ''}
-        childNodes={children}
-        sxRenderer={sxRenderer}
-        renderers={renderers}
-      />
-    )
-  }
-
   if (Component) {
     return (
       <Component {...props} sx={sx}>
@@ -181,21 +170,12 @@ export type RichTextProps = { raw: ElementNode } & {
   withMargin?: boolean
 }
 
-const hygraphClassRenderer = {
-  class: (props) => {
-    const RenderType = defaultRenderers[props.children.props.childNodes[0].type]
-    const { className, ...rest } = props
-
-    return <RenderType className={className} {...rest} />
-  },
-}
-
 export function RichText({ raw, sxRenderer, renderers, withMargin = false }: RichTextProps) {
   return (
     <RenderChildren
       childNodes={raw.children}
       sxRenderer={mergeSxRenderer(defaultSxRenderer, sxRenderer)}
-      renderers={{ ...defaultRenderers, ...hygraphClassRenderer, ...renderers }}
+      renderers={{ ...defaultRenderers, ...renderers }}
       noMargin={!withMargin}
     />
   )

--- a/packages/hygraph-ui/components/RichText/defaultRenderers.tsx
+++ b/packages/hygraph-ui/components/RichText/defaultRenderers.tsx
@@ -54,4 +54,5 @@ export const defaultRenderers: Renderers = {
   bold: (props) => <Box component='strong' fontWeight='bold' {...props} />,
   italic: (props) => <Box component='em' fontStyle='italic' {...props} />,
   underlined: (props) => <Box component='span' {...props} />,
+  class: (props) => <Box component='div' {...props} />,
 }

--- a/packages/hygraph-ui/components/RichText/types.ts
+++ b/packages/hygraph-ui/components/RichText/types.ts
@@ -12,7 +12,6 @@ type BaseElementTypes =
   | 'numbered-list'
   | 'bulleted-list'
   | 'block-quote'
-  | 'paragraph'
   | 'list-item'
   | 'list-item-child'
   | 'table'
@@ -46,6 +45,12 @@ type LinkElement = {
   openInNewTab?: boolean
 }
 
+type ClassElement = {
+  type: 'class'
+  children: ElementOrTextNode[]
+  className: string
+}
+
 type ImageElement = {
   type: 'image'
   children: ElementOrTextNode[]
@@ -74,7 +79,13 @@ type IframeElement = {
   height?: number
 }
 
-export type ElementNode = SimpleElement | LinkElement | ImageElement | VideoElement | IframeElement
+export type ElementNode =
+  | SimpleElement
+  | LinkElement
+  | ImageElement
+  | VideoElement
+  | IframeElement
+  | ClassElement
 export type ElementOrTextNode = ElementNode | TextNode
 
 type RendererBase = { sx?: SxProps<Theme>; children?: React.ReactNode }
@@ -89,6 +100,7 @@ export type Renderers = {
   image: Renderer<ImageElement>
   video: Renderer<VideoElement>
   iframe: Renderer<IframeElement>
+  class: Renderer<ClassElement>
 }
 
 export type SxRenderer = {

--- a/packages/hygraph-ui/components/RichText/types.ts
+++ b/packages/hygraph-ui/components/RichText/types.ts
@@ -100,4 +100,5 @@ export type AdditionalProps = {
   sxRenderer: SxRenderer
   first?: boolean
   last?: boolean
+  className?: string
 }


### PR DESCRIPTION
Previously, when adding a CSS class to a node in Hygraph:
![Screenshot 2023-10-03 at 16 00 43](https://github.com/graphcommerce-org/graphcommerce/assets/31548701/c3844928-eca3-434a-99e2-aa5fbf1fd48a)

This would result in an error:
![Screenshot 2023-10-03 at 16 01 30](https://github.com/graphcommerce-org/graphcommerce/assets/31548701/3fea4936-b7f7-4caf-9ba1-6887648f8f5d)

Now this no longer throws an error and applies the classes instead.
![Screenshot 2023-10-03 at 16 01 30](https://github.com/graphcommerce-org/graphcommerce/assets/31548701/2d42208e-4626-4f85-9a88-ca4c9b541521)
