### PR TITLE
[GCOM-1266] Fix editAddressForm when addition is nullable

### DIFF
--- a/.changeset/tall-spies-reflect.md
+++ b/.changeset/tall-spies-reflect.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/magento-customer': patch
+---
+
+Fix EditAddressForm when addition field is null or undefined

--- a/packages/magento-customer/components/EditAddressForm/EditAddressForm.tsx
+++ b/packages/magento-customer/components/EditAddressForm/EditAddressForm.tsx
@@ -50,7 +50,7 @@ export function EditAddressForm(props: EditAddressFormProps) {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         houseNumber: address?.street?.[1],
-        addition: address?.street?.[2],
+        addition: address?.street?.[2] ?? '',
       },
       onBeforeSubmit: (formData) => {
         const region = countries

--- a/packages/magento-customer/components/EditAddressForm/EditAddressForm.tsx
+++ b/packages/magento-customer/components/EditAddressForm/EditAddressForm.tsx
@@ -47,9 +47,7 @@ export function EditAddressForm(props: EditAddressFormProps) {
         city: address?.city,
         countryCode: address?.country_code,
         telephone: address?.telephone,
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        houseNumber: address?.street?.[1],
+        houseNumber: address?.street?.[1] ?? '',
         addition: address?.street?.[2] ?? '',
       },
       onBeforeSubmit: (formData) => {


### PR DESCRIPTION
- [GCOM Ticket](https://hoproj.atlassian.net/browse/GCOM-1266)
- [On request of Bouwprofi](https://hoproj.atlassian.net/browse/BPGC-215)

### Error
Magento gave an internal error when addition field was null or undefined. This was a magento bug but simply fixed by sending an empty string if addition is not given
<img width="1527" alt="image" src="https://github.com/graphcommerce-org/graphcommerce/assets/49681263/7387e53f-0f02-4f9b-a08a-5050f63a2cb9">
