### PR TITLE
Split off known issues to separate page

### DIFF
--- a/.changeset/friendly-dogs-shop.md
+++ b/.changeset/friendly-dogs-shop.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/docs': minor
+---
+
+Split off Magento known issues to separate page

--- a/docs/magento/known-issues.md
+++ b/docs/magento/known-issues.md
@@ -1,0 +1,26 @@
+---
+menu: Known issues
+---
+
+# Known issues
+
+An overview of bugs and limitations you may run into with Magento's GraphQL API:
+
+## Cart-related mutations result in `Can not find cart with ID` or `Cart isn't active` errors
+
+This is caused by a regression in Magento 2.4.6, which results in some GraphQL
+errors no longer getting a category extension string (such as
+`graphql-no-such-entity`). Normally, these errors are handling by automatically
+creating a new cart, but without the proper error category this error-handling
+logic is nog triggered.
+
+As a workaround, you can apply
+[cart-error-category.patch](./patches/cart-error-category.patch). This
+regression is fixed as of Magento 2.4.7-beta2.
+
+See also
+https://github.com/magento/magento2/commit/49cbe774020d3dfa6ee2b8702376a947801c9971
+
+## Next steps
+
+- [Overview](./readme)

--- a/docs/magento/known-issues.md
+++ b/docs/magento/known-issues.md
@@ -27,7 +27,7 @@ During customer login, GraphCommerce queries Magento to determine whether the
 customer account already exists or not. If not, the sign-up form is shown
 instead.
 
-In Magento 2.4.7+ and recent security patch updates, the behavior of the
+In Magento 2.4.7+ and recent security updates, the behavior of the
 `isEmailAvailable` query that is used to do this was made dependent on the
 `Enable Guest Checkout Login` configuration setting. If disabled, this query
 will always return `true`, resulting in the sign-up form always being shown,

--- a/docs/magento/known-issues.md
+++ b/docs/magento/known-issues.md
@@ -21,6 +21,24 @@ regression is fixed as of Magento 2.4.7-beta2.
 See also
 https://github.com/magento/magento2/commit/49cbe774020d3dfa6ee2b8702376a947801c9971
 
+## Customer is forced to sign up, even if already registered
+
+During customer login, GraphCommerce queries Magento to determine whether the
+customer account already exists or not. If not, the sign-up form is shown
+instead.
+
+In Magento 2.4.7+ and recent security patch updates, the behavior of the
+`isEmailAvailable` query that is used to do this was made dependent on the
+`Enable Guest Checkout Login` configuration setting. If disabled, this query
+will always return `true`, resulting in the sign-up form always being shown,
+even if the customer already exists.
+
+To solve this, the following setting must be set to `Yes`:
+`Stores -> Configuration -> Sales -> Checkout -> Checkout Options -> Enable Guest Checkout Login`
+
+See also
+https://developer.adobe.com/commerce/php/development/backward-incompatible-changes/highlights/#isemailavailable-api
+
 ## Next steps
 
 - [Overview](./readme)

--- a/docs/magento/known-issues.md
+++ b/docs/magento/known-issues.md
@@ -8,30 +8,40 @@ An overview of bugs and limitations you may run into with Magento's GraphQL API:
 
 ## Cart-related mutations result in `Can not find cart with ID` or `Cart isn't active` errors
 
-This is caused by a regression in Magento 2.4.6, which results in some GraphQL
-errors no longer getting a category extension string (such as
-`graphql-no-such-entity`). Normally, these errors are handling by automatically
-creating a new cart, but without the proper error category this error-handling
-logic is nog triggered.
+Affected Magento versions:
+
+- `2.4.7`: only `2.4.7-beta1`
+- `2.4.6`: all versions
+
+This is caused by a regression which results in some GraphQL errors no longer
+getting a category extension string (such as `graphql-no-such-entity`).
+Normally, these errors are handling by automatically creating a new cart, but
+without the proper error category this error-handling logic is nog triggered.
 
 As a workaround, you can apply
-[cart-error-category.patch](./patches/cart-error-category.patch). This
-regression is fixed as of Magento 2.4.7-beta2.
+[cart-error-category.patch](./patches/cart-error-category.patch).
 
 See also
 https://github.com/magento/magento2/commit/49cbe774020d3dfa6ee2b8702376a947801c9971
 
 ## Customer is forced to sign up, even if already registered
 
+Affected Magento versions:
+
+- `2.4.7` and all future release series
+- `2.4.6`: `2.4.6-p1` and up
+- `2.4.5`: `2.4.5-p3` and up
+- `2.4.4`: `2.4.4-p4` and up
+
 During customer login, GraphCommerce queries Magento to determine whether the
 customer account already exists or not. If not, the sign-up form is shown
 instead.
 
-In Magento 2.4.7+ and recent security updates, the behavior of the
-`isEmailAvailable` query that is used to do this was made dependent on the
-`Enable Guest Checkout Login` configuration setting. If disabled, this query
-will always return `true`, resulting in the sign-up form always being shown,
-even if the customer already exists.
+In affected Magento versions, the behavior of the `isEmailAvailable` query that
+is used to do this was made dependent on the `Enable Guest Checkout Login`
+configuration setting. If disabled, this query will always return `true`,
+resulting in the sign-up form always being shown, even if the customer already
+exists.
 
 To solve this, the following setting must be set to `Yes`:
 `Stores -> Configuration -> Sales -> Checkout -> Checkout Options -> Enable Guest Checkout Login`

--- a/docs/magento/readme.md
+++ b/docs/magento/readme.md
@@ -70,16 +70,6 @@ Remove the URL suffixes from products and categories. (default is `.html`)
 `Stores -> Configuration -> Catalog -> Catalog -> Search Engine Optimization -> Product URL Suffix`
 `Stores -> Configuration -> Catalog -> Catalog -> Search Engine Optimization -> Category URL Suffix`
 
-### Enable guest checkout login
-
-During customer login, GraphCommerce queries Magento to determine whether the
-customer account already exists. To do this the following setting must be set to
-Yes:
-`Stores -> Configuration -> Sales -> Checkout -> Checkout Options -> Enable Guest Checkout Login`
-
-If this is not set correctly, customers will not be able to log in, since they
-will always be prompted to create a new account.
-
 ## Optional packages
 
 - [Store Pickup / MSI](https://github.com/graphcommerce-org/graphcommerce/tree/main/packages/magento-cart-pickup)

--- a/docs/magento/readme.md
+++ b/docs/magento/readme.md
@@ -7,6 +7,12 @@ menu: Overview
 To integrate with Magento, most of the functionality should work out-of-the box
 if Magento exposes a working GraphQL API.
 
+Some additional configuration may be required, which is documented below.
+
+Currently, the GraphQL API also has some bugs and limitations which in some
+cases requires a patch to work around, please see
+[Known issues](./known-issues.md)
+
 ## Magento configuration
 
 ### Configure Base Link Url to get emails working
@@ -92,22 +98,4 @@ will always be prompted to create a new account.
 
 - [Full feature list](../feature-list.md)
 - [SEO Migration](./seo-migration.md)
-
-## Known issues
-
-An overview of bugs and limitations you may run into with Magento's GraphQL API:
-
-### Cart-related mutations result `Can not find cart with ID` or `Cart isn't active` errors
-
-This is caused by a regression in Magento 2.4.6, which results in some GraphQL
-errors no longer getting a category extension string (such as
-`graphql-no-such-entity`). Normally, these errors are handling by automatically
-creating a new cart, but without the proper error category this error-handling
-logic is nog triggered.
-
-As a workaround, you can apply
-[cart-error-category.patch](./patches/cart-error-category.patch). This
-regression is fixed as of Magento 2.4.7-beta2.
-
-See also
-https://github.com/magento/magento2/commit/49cbe774020d3dfa6ee2b8702376a947801c9971
+- [Known issues](./known-issues.md)


### PR DESCRIPTION
This keeps the overview free of clutter, keeps the 'Next steps' section
at the bottom.