### PR TITLE
Fix/mollie empty cart

### DIFF
--- a/.changeset/poor-badgers-heal.md
+++ b/.changeset/poor-badgers-heal.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/mollie-magento-payment': patch
+---
+
+Fixed the issue where a guest returned to a empty cart after a canceled payment with Mollie

--- a/packages/mollie-magento-payment/components/MolliePaymentHandler/MolliePaymentHandler.tsx
+++ b/packages/mollie-magento-payment/components/MolliePaymentHandler/MolliePaymentHandler.tsx
@@ -1,5 +1,9 @@
 import { useMutation } from '@graphcommerce/graphql'
-import { ApolloCartErrorFullPage, useClearCurrentCartId } from '@graphcommerce/magento-cart'
+import {
+  ApolloCartErrorFullPage,
+  useAssignCurrentCartId,
+  useClearCurrentCartId,
+} from '@graphcommerce/magento-cart'
 import {
   PaymentHandlerProps,
   usePaymentMethodContext,
@@ -20,6 +24,7 @@ export function MolliePaymentHandler({ code }: PaymentHandlerProps) {
   const [lockState] = useCartLockWithToken()
 
   const clear = useClearCurrentCartId()
+  const assignCartId = useAssignCurrentCartId()
 
   const isActive = selectedMethod?.code === code || lockState.method === code
 
@@ -55,6 +60,7 @@ export function MolliePaymentHandler({ code }: PaymentHandlerProps) {
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         onSuccess(lockState.order_number ?? '')
       } else if (returnedCartId) {
+        assignCartId(returnedCartId)
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         router.replace('/checkout/payment')
       }


### PR DESCRIPTION
Previously when a guest canceled a payment with Mollie, the user returned to the `checkout/payment` page with a wrong cart id. This resulted in a "empty cart" screen. The reason this only went wrong for the guest users is because createEmptyCart returns the active cart for authenticated user, but for guests this returns a new cart every single time.

Reproductions steps:
- Go to `checkout/payment` as an unauthenticated user.
- Select IDeal as payment method, choose any bank of your liking.
- On the PSP Portal, cancel the payment. You will be returned to `checkout/payment`
- Previously you would see an "empty cart" screen, but now you can see the unlocked cart.