### PR TITLE
Make `canonicalize()` work correctly when i18n domain routing is used

### DIFF
--- a/.changeset/few-bats-sit.md
+++ b/.changeset/few-bats-sit.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/next-ui': patch
+---
+
+Fix incorrect canonical URLs when i18n domain routing is used

--- a/examples/magento-graphcms/graphcommerce.config.js.example
+++ b/examples/magento-graphcms/graphcommerce.config.js.example
@@ -9,7 +9,10 @@ const config = {
   hygraphEndpoint: 'https://eu-central-1.cdn.hygraph.com/content/ckhx7xadya6xs01yxdujt8i80/master',
   magentoEndpoint: 'https://backend.reachdigital.dev/graphql',
   canonicalBaseUrl: 'https://graphcommerce.vercel.app',
-  storefront: [{ locale: 'en', magentoStoreCode: 'en_US' }],
+  storefront: [
+    { locale: 'en', magentoStoreCode: 'en_US', defaultLocale: true },
+    { locale: 'nl', magentoStoreCode: 'nl_NL' },
+  ],
   recentlyViewedProducts: {
     enabled: true,
   },

--- a/packages/next-ui/PageMeta/PageMeta.tsx
+++ b/packages/next-ui/PageMeta/PageMeta.tsx
@@ -60,18 +60,25 @@ export function canonicalize(router: PartialNextRouter, incoming?: Canonical) {
     const curLocale = router.locale
 
     // Copied from here https://github.com/vercel/next.js/blob/213c42f446874d29d07fa2cca6e6b11fc9c3b711/packages/next/client/link.tsx#L512
-    const localeDomain =
-      router.isLocaleDomain &&
-      getDomainLocale(as, curLocale, router && router.locales, router.domainLocales)
+    const localeDomain = getDomainLocale(
+      as,
+      curLocale,
+      router && router.locales,
+      router.domainLocales,
+    )
 
-    href = localeDomain || addBasePath(addLocale(as, curLocale, router.defaultLocale))
+    if (localeDomain) {
+      canonical = localeDomain
+    } else {
+      href = localeDomain || addBasePath(addLocale(as, curLocale, router.defaultLocale))
 
-    let siteUrl =
-      storefrontConfig(router.locale)?.canonicalBaseUrl ||
-      import.meta.graphCommerce.canonicalBaseUrl
-    if (siteUrl.endsWith('/')) siteUrl = siteUrl.slice(0, -1)
+      let siteUrl =
+        storefrontConfig(router.locale)?.canonicalBaseUrl ||
+        import.meta.graphCommerce.canonicalBaseUrl
+      if (siteUrl.endsWith('/')) siteUrl = siteUrl.slice(0, -1)
 
-    canonical = `${siteUrl}${href}`
+      canonical = `${siteUrl}${href}`
+    }
   }
 
   if (!canonical.startsWith('http')) {

--- a/packages/next-ui/PageMeta/PageMeta.tsx
+++ b/packages/next-ui/PageMeta/PageMeta.tsx
@@ -70,7 +70,7 @@ export function canonicalize(router: PartialNextRouter, incoming?: Canonical) {
     if (localeDomain) {
       canonical = localeDomain
     } else {
-      href = localeDomain || addBasePath(addLocale(as, curLocale, router.defaultLocale))
+      href = addBasePath(addLocale(as, curLocale, router.defaultLocale))
 
       let siteUrl =
         storefrontConfig(router.locale)?.canonicalBaseUrl ||


### PR DESCRIPTION
Two issues were preventing `canonicalize()` from working correctly when using locale domains:

- During local development, `router.isLocaleDomain` is incorrectly set to `false`, even when a locale domain is used. See also https://github.com/vercel/next.js/issues/35775

- `getDomainLocale` was being used incorrectly, as it will either return `false` if no locale domain is used (which fortunately does work correctly during local development), or else it will return a fully built URL including locale domain - so we should not prefix it with the `canonicalBaseUrl` ourselves. We can also use this to replace the `router.isLocaleDomain` check, to make things work correctly during local development as well.

Fix was also tested without using locale domains