### PR TITLE
feat(GCOM-1318): dismiss login page and go back to previous page asap when logging in

### DIFF
--- a/.changeset/rotten-lions-chew.md
+++ b/.changeset/rotten-lions-chew.md
@@ -1,5 +1,5 @@
 ---
-"@graphcommerce/magento-customer": patch
+'@graphcommerce/magento-customer': patch
 ---
 
-feat(GCOM-1318): dismiss login page and go back to previous page asap when logging in
+Dismiss login page and go back to previous page asap when logging in

--- a/.changeset/rotten-lions-chew.md
+++ b/.changeset/rotten-lions-chew.md
@@ -1,0 +1,5 @@
+---
+"@graphcommerce/magento-customer": patch
+---
+
+feat(GCOM-1318): dismiss login page and go back to previous page asap when logging in

--- a/packages/magento-customer/hooks/useAccountSignInUpForm.tsx
+++ b/packages/magento-customer/hooks/useAccountSignInUpForm.tsx
@@ -9,6 +9,8 @@ import {
   IsEmailAvailableQueryVariables,
 } from './IsEmailAvailable.gql'
 import { useCustomerSession } from './useCustomerSession'
+import { useGo, usePageContext } from '@graphcommerce/framer-next-pages'
+import { useShowBack } from '@graphcommerce/next-ui/Layout/components/LayoutHeaderBack'
 
 export type UseFormIsEmailAvailableProps = {
   onSubmitted?: (data: { email: string }) => void
@@ -72,6 +74,12 @@ export function useAccountSignInUpForm(props: UseFormIsEmailAvailableProps = {})
 
     if (isValid && isSubmitSuccessful) mode = hasAccount ? 'signin' : 'signup'
   }
+
+  const { closeSteps = 0 } = usePageContext() ?? {}
+  useEffect(() => {
+    // Automatically close the overlay if the user is signed in
+    if (mode === 'signedin' && closeSteps > 0) window.history.go(closeSteps * -1)
+  }, [mode, closeSteps])
 
   return { mode, form, submit }
 }

--- a/packages/magento-customer/hooks/useAccountSignInUpForm.tsx
+++ b/packages/magento-customer/hooks/useAccountSignInUpForm.tsx
@@ -1,3 +1,4 @@
+import { usePageContext } from '@graphcommerce/framer-next-pages'
 import { useQuery } from '@graphcommerce/graphql'
 import { useFormGqlQuery } from '@graphcommerce/react-hook-form'
 import { useRouter } from 'next/router'
@@ -9,8 +10,6 @@ import {
   IsEmailAvailableQueryVariables,
 } from './IsEmailAvailable.gql'
 import { useCustomerSession } from './useCustomerSession'
-import { useGo, usePageContext } from '@graphcommerce/framer-next-pages'
-import { useShowBack } from '@graphcommerce/next-ui/Layout/components/LayoutHeaderBack'
 
 export type UseFormIsEmailAvailableProps = {
   onSubmitted?: (data: { email: string }) => void

--- a/packages/magento-customer/package.json
+++ b/packages/magento-customer/package.json
@@ -14,6 +14,7 @@
   "peerDependencies": {
     "@graphcommerce/ecommerce-ui": "^8.0.0-canary.87",
     "@graphcommerce/eslint-config-pwa": "^8.0.0-canary.87",
+    "@graphcommerce/framer-next-pages": "^8.0.0-canary.87",
     "@graphcommerce/framer-utils": "^8.0.0-canary.87",
     "@graphcommerce/graphql": "^8.0.0-canary.87",
     "@graphcommerce/graphql-mesh": "^8.0.0-canary.87",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3591,6 +3591,7 @@ __metadata:
   peerDependencies:
     "@graphcommerce/ecommerce-ui": ^8.0.0-canary.87
     "@graphcommerce/eslint-config-pwa": ^8.0.0-canary.87
+    "@graphcommerce/framer-next-pages": ^8.0.0-canary.87
     "@graphcommerce/framer-utils": ^8.0.0-canary.87
     "@graphcommerce/graphql": ^8.0.0-canary.87
     "@graphcommerce/graphql-mesh": ^8.0.0-canary.87


### PR DESCRIPTION
This is pretty bare-bones right now. It just logs you in and returns you to the previous page.
It feels pretty frictionless to me, but might be lacking in feedback a little bit?

Having a sceen with "You're now logg in. [Continue shopping]" is clear but does not really add much either. 
Redirecting to the account page after logging in also feels pretty silly.

This might be one of those things that feels unnatural at first, but I think it provides value by effortlessly continuing what you were doing before logging in. Therefore it might feel right pretty fast.

Thanks for reading this long essay about a trivial issue, have a great day!

