### PR TITLE
Fix/customizable options do not show in cart

### DIFF
--- a/.changeset/purple-eggs-float.md
+++ b/.changeset/purple-eggs-float.md
@@ -1,0 +1,6 @@
+---
+"@graphcommerce/magento-product-configurable": patch
+"@graphcommerce/magento-cart-items": patch
+---
+
+Fixed a bug concerning customizable options. Customizable options of configurable products are shown again in the cart.

--- a/packages/magento-cart-items/components/SelectedCustomizableOptions/SelectedCustomizableOptions.tsx
+++ b/packages/magento-cart-items/components/SelectedCustomizableOptions/SelectedCustomizableOptions.tsx
@@ -6,12 +6,14 @@ import { SelectedCustomizableOptionFragment } from './SelectedCustomizableOption
 
 type SelectedCustomizableOptionProps = CartItemFragment & {
   customizable_options?: (SelectedCustomizableOptionFragment | null | undefined)[] | null
+  configurable_customizable?: (SelectedCustomizableOptionFragment | null | undefined)[] | null
 }
 
 export function SelectedCustomizableOptions(props: SelectedCustomizableOptionProps) {
-  const { customizable_options, product } = props
-
-  const options = filterNonNullableKeys(customizable_options, [])
+  const { customizable_options, product, configurable_customizable } = props
+  const options = customizable_options
+    ? filterNonNullableKeys(customizable_options, [])
+    : filterNonNullableKeys(configurable_customizable, [])
 
   if (!options.length) return null
 

--- a/packages/magento-product-configurable/plugins/ConfigurableCartItemActionCard.tsx
+++ b/packages/magento-product-configurable/plugins/ConfigurableCartItemActionCard.tsx
@@ -33,10 +33,7 @@ export function ConfigurableCartItemActionCard(
       details={
         <>
           {rest.details}
-          <ConfigurableCartItemOptions
-            {...rest.cartItem}
-            productPrice={rest.cartItem.product.price_range.minimum_price.final_price.value}
-          />
+          <ConfigurableCartItemOptions {...rest.cartItem} />
         </>
       }
     />


### PR DESCRIPTION
You can test this issue by adding this product: https://graphcommerce-git-fix-customizable-options-1dd089-graphcommerce.vercel.app/nl/p/spooky-girl-size-41-46-gc-1-sock-46 and adding this product: https://graphcommerce-git-fix-customizable-options-1dd089-graphcommerce.vercel.app/nl/p/spooky-girl-gc-1-sock to your cart. Both product should show customizable options in the cart.