### PR TITLE
CheckboxElement, MultiSelectElement, NumberFieldElement, SelectElement, SliderElement and TextFieldElement have their inputRef passed, allowing focus to be set by the form.

### DIFF
--- a/.changeset/eight-flowers-heal.md
+++ b/.changeset/eight-flowers-heal.md
@@ -2,4 +2,4 @@
 '@graphcommerce/ecommerce-ui': patch
 ---
 
-Invalid checkboxes are now focussed
+CheckboxElement, MultiSelectElement, NumberFieldElement, SelectElement, SliderElement and TextFieldElement have their inputRef passed, allowing focus to be set by the form.

--- a/.changeset/eight-flowers-heal.md
+++ b/.changeset/eight-flowers-heal.md
@@ -1,0 +1,5 @@
+---
+"@graphcommerce/ecommerce-ui": minor
+---
+
+Invalid checkboxes are now focussed

--- a/.changeset/eight-flowers-heal.md
+++ b/.changeset/eight-flowers-heal.md
@@ -1,5 +1,5 @@
 ---
-"@graphcommerce/ecommerce-ui": minor
+'@graphcommerce/ecommerce-ui': patch
 ---
 
 Invalid checkboxes are now focussed

--- a/packages/ecommerce-ui/components/FormComponents/CheckboxElement.tsx
+++ b/packages/ecommerce-ui/components/FormComponents/CheckboxElement.tsx
@@ -64,8 +64,8 @@ export function CheckboxElement<TFieldValues extends FieldValues>({
                 label={label || ''}
                 control={
                   <Checkbox
-                    inputRef={checkboxRef}
                     {...rest}
+                    inputRef={checkboxRef}
                     color={rest.color || 'primary'}
                     sx={{
                       ...(Array.isArray(sx) ? sx : [sx]),

--- a/packages/ecommerce-ui/components/FormComponents/CheckboxElement.tsx
+++ b/packages/ecommerce-ui/components/FormComponents/CheckboxElement.tsx
@@ -47,7 +47,8 @@ export function CheckboxElement<TFieldValues extends FieldValues>({
       name={name}
       rules={rules}
       control={control}
-      render={({ field: { value, onChange, ref }, fieldState: { invalid, error } }) => {
+      render={({ field: { value, onChange, ref, ...field }, fieldState: { invalid, error } }) => {
+        // eslint-disable-next-line no-nested-ternary
         const parsedHelperText = error
           ? typeof parseError === 'function'
             ? parseError(error)
@@ -61,6 +62,7 @@ export function CheckboxElement<TFieldValues extends FieldValues>({
                 control={
                   <Checkbox
                     {...rest}
+                    {...field}
                     inputRef={ref}
                     color={rest.color || 'primary'}
                     sx={{
@@ -69,9 +71,7 @@ export function CheckboxElement<TFieldValues extends FieldValues>({
                     }}
                     value={value}
                     checked={!!value}
-                    onChange={() => {
-                      onChange(!value)
-                    }}
+                    onChange={() => onChange(!value)}
                   />
                 }
               />

--- a/packages/ecommerce-ui/components/FormComponents/CheckboxElement.tsx
+++ b/packages/ecommerce-ui/components/FormComponents/CheckboxElement.tsx
@@ -17,7 +17,6 @@ import {
   SxProps,
   Theme,
 } from '@mui/material'
-import { useRef } from 'react'
 
 export type CheckboxElementProps<T extends FieldValues> = Omit<CheckboxProps, 'name'> & {
   parseError?: (error: FieldError) => string
@@ -43,15 +42,12 @@ export function CheckboxElement<TFieldValues extends FieldValues>({
     rules.required = i18n._(/* i18n */ 'This field is required')
   }
 
-  const checkboxRef = useRef<HTMLInputElement>(null)
-
   return (
     <Controller
       name={name}
       rules={rules}
       control={control}
-      render={({ field: { value, onChange }, fieldState: { invalid, error } }) => {
-        if (invalid) checkboxRef.current?.focus()
+      render={({ field: { value, onChange, ref }, fieldState: { invalid, error } }) => {
         const parsedHelperText = error
           ? typeof parseError === 'function'
             ? parseError(error)
@@ -65,7 +61,7 @@ export function CheckboxElement<TFieldValues extends FieldValues>({
                 control={
                   <Checkbox
                     {...rest}
-                    inputRef={checkboxRef}
+                    inputRef={ref}
                     color={rest.color || 'primary'}
                     sx={{
                       ...(Array.isArray(sx) ? sx : [sx]),

--- a/packages/ecommerce-ui/components/FormComponents/CheckboxElement.tsx
+++ b/packages/ecommerce-ui/components/FormComponents/CheckboxElement.tsx
@@ -17,6 +17,7 @@ import {
   SxProps,
   Theme,
 } from '@mui/material'
+import { useRef } from 'react'
 
 export type CheckboxElementProps<T extends FieldValues> = Omit<CheckboxProps, 'name'> & {
   parseError?: (error: FieldError) => string
@@ -42,12 +43,15 @@ export function CheckboxElement<TFieldValues extends FieldValues>({
     rules.required = i18n._(/* i18n */ 'This field is required')
   }
 
+  const checkboxRef = useRef<HTMLInputElement>(null)
+
   return (
     <Controller
       name={name}
       rules={rules}
       control={control}
       render={({ field: { value, onChange }, fieldState: { invalid, error } }) => {
+        if (invalid) checkboxRef.current?.focus()
         const parsedHelperText = error
           ? typeof parseError === 'function'
             ? parseError(error)
@@ -60,6 +64,7 @@ export function CheckboxElement<TFieldValues extends FieldValues>({
                 label={label || ''}
                 control={
                   <Checkbox
+                    inputRef={checkboxRef}
                     {...rest}
                     color={rest.color || 'primary'}
                     sx={{

--- a/packages/ecommerce-ui/components/FormComponents/MultiSelectElement.tsx
+++ b/packages/ecommerce-ui/components/FormComponents/MultiSelectElement.tsx
@@ -72,7 +72,7 @@ export function MultiSelectElement<TFieldValues extends FieldValues>(
       name={name}
       rules={rules}
       control={control}
-      render={({ field: { value, onChange, onBlur }, fieldState: { invalid, error } }) => {
+      render={({ field: { value, onChange, ...field }, fieldState: { invalid, error } }) => {
         helperText = error
           ? typeof parseError === 'function'
             ? parseError(error)
@@ -102,6 +102,7 @@ export function MultiSelectElement<TFieldValues extends FieldValues>(
             )}
             <Select
               {...rest}
+              {...field}
               id={rest.id || `select-multi-select-${name}`}
               multiple
               label={label || undefined}
@@ -109,7 +110,6 @@ export function MultiSelectElement<TFieldValues extends FieldValues>(
               value={value || []}
               required={required}
               onChange={onChange}
-              onBlur={onBlur}
               MenuProps={{
                 ...rest.MenuProps,
                 PaperProps: {
@@ -126,23 +126,23 @@ export function MultiSelectElement<TFieldValues extends FieldValues>(
                 typeof rest.renderValue === 'function'
                   ? rest.renderValue
                   : showChips
-                  ? (selected) => (
-                      <div style={{ display: 'flex', flexWrap: 'wrap' }}>
-                        {((selected as any[]) || []).map((selectedValue) => (
-                          <Chip
-                            key={selectedValue}
-                            label={selectedValue}
-                            style={{ display: 'flex', flexWrap: 'wrap' }}
-                            onDelete={() => {
-                              onChange(value.filter((i: any) => i !== selectedValue))
-                              // setValue(name, formValue.filter((i: any) => i !== value), { shouldValidate: true })
-                            }}
-                            deleteIcon={<IconSvg src={iconClose} />}
-                          />
-                        ))}
-                      </div>
-                    )
-                  : (selected) => (Array.isArray(selected) ? selected.join(', ') : '')
+                    ? (selected) => (
+                        <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+                          {((selected as any[]) || []).map((selectedValue) => (
+                            <Chip
+                              key={selectedValue}
+                              label={selectedValue}
+                              style={{ display: 'flex', flexWrap: 'wrap' }}
+                              onDelete={() => {
+                                onChange(value.filter((i: any) => i !== selectedValue))
+                                // setValue(name, formValue.filter((i: any) => i !== value), { shouldValidate: true })
+                              }}
+                              deleteIcon={<IconSvg src={iconClose} />}
+                            />
+                          ))}
+                        </div>
+                      )
+                    : (selected) => (Array.isArray(selected) ? selected.join(', ') : '')
               }
             >
               {options.map((item) => {

--- a/packages/ecommerce-ui/components/FormComponents/NumberFieldElement.tsx
+++ b/packages/ecommerce-ui/components/FormComponents/NumberFieldElement.tsx
@@ -54,21 +54,21 @@ export function NumberFieldElement<T extends FieldValues>(props: NumberFieldElem
       control={control}
       rules={rules}
       defaultValue={defaultValue}
-      render={({ field: { value, onChange, onBlur }, fieldState: { invalid, error } }) => {
+      render={({ field: { value, onChange, ref, ...field }, fieldState: { invalid, error } }) => {
         const valueAsNumber = value ? parseFloat(value) : 0
 
         return (
           <TextField
             {...textFieldProps}
-            variant={variant}
-            name={name}
+            {...field}
+            inputRef={ref}
             value={value ?? ''}
             onChange={(ev) => {
               const newValue = (ev.target as HTMLInputElement).valueAsNumber
               onChange(Number.isNaN(newValue) ? '' : newValue)
               textFieldProps.onChange?.(ev)
             }}
-            onBlur={onBlur}
+            variant={variant}
             required={required}
             error={invalid}
             helperText={error ? error.message : textFieldProps.helperText}

--- a/packages/ecommerce-ui/components/FormComponents/SelectElement.tsx
+++ b/packages/ecommerce-ui/components/FormComponents/SelectElement.tsx
@@ -49,6 +49,7 @@ export function SelectElement<TFieldValues extends FieldValues, O extends Option
             {...rest}
             value={value ?? ''}
             {...field}
+            inputRef={ref}
             onChange={(event) => {
               let item: number | string | O | undefined = event.target.value
               if (type === 'number') item = Number(item)

--- a/packages/ecommerce-ui/components/FormComponents/SelectElement.tsx
+++ b/packages/ecommerce-ui/components/FormComponents/SelectElement.tsx
@@ -37,7 +37,7 @@ export function SelectElement<TFieldValues extends FieldValues, O extends Option
       rules={validation}
       control={control}
       defaultValue={defaultValue}
-      render={({ field: { onBlur, onChange, value }, fieldState: { invalid, error } }) => {
+      render={({ field: { onChange, value, ref, ...field }, fieldState: { invalid, error } }) => {
         // handle shrink on number input fields
         if (type === 'number' && typeof value !== 'undefined') {
           rest.InputLabelProps = rest.InputLabelProps || {}
@@ -47,9 +47,8 @@ export function SelectElement<TFieldValues extends FieldValues, O extends Option
         return (
           <TextField
             {...rest}
-            name={name}
             value={value ?? ''}
-            onBlur={onBlur}
+            {...field}
             onChange={(event) => {
               let item: number | string | O | undefined = event.target.value
               if (type === 'number') item = Number(item)

--- a/packages/ecommerce-ui/components/FormComponents/SliderElement.tsx
+++ b/packages/ecommerce-ui/components/FormComponents/SliderElement.tsx
@@ -39,7 +39,7 @@ export function SliderElement<TFieldValues extends FieldValues>({
       name={name}
       control={control}
       rules={rules}
-      render={({ field: { onChange, value }, fieldState: { invalid, error } }) => {
+      render={({ field, fieldState: { invalid, error } }) => {
         const parsedHelperText = error
           ? typeof parseError === 'function'
             ? parseError(error)
@@ -52,12 +52,7 @@ export function SliderElement<TFieldValues extends FieldValues>({
                 {label}
               </FormLabel>
             )}
-            <Slider
-              {...other}
-              value={value}
-              onChange={onChange}
-              valueLabelDisplay={other.valueLabelDisplay || 'auto'}
-            />
+            <Slider {...other} {...field} valueLabelDisplay={other.valueLabelDisplay || 'auto'} />
             {parsedHelperText && (
               <FormHelperText error={invalid}>{parsedHelperText}</FormHelperText>
             )}

--- a/packages/ecommerce-ui/components/FormComponents/TextFieldElement.tsx
+++ b/packages/ecommerce-ui/components/FormComponents/TextFieldElement.tsx
@@ -43,23 +43,21 @@ export function TextFieldElement<TFieldValues extends FieldValues>({
       control={control}
       rules={validation}
       defaultValue={defaultValue}
-      render={({ field: { value, onChange, onBlur, ref }, fieldState: { error } }) => (
+      render={({ field: { onChange, ref, ...field }, fieldState: { error } }) => (
         <TextField
           {...rest}
-          name={name}
-          value={value ?? ''}
+          {...field}
           onChange={(ev) => {
             onChange(
               type === 'number' && ev.target.value ? Number(ev.target.value) : ev.target.value,
             )
             rest.onChange?.(ev)
           }}
-          onBlur={onBlur}
+          inputRef={ref}
           required={required}
           type={type}
           error={Boolean(error) || rest.error}
           helperText={error ? error.message : rest.helperText}
-          inputRef={ref}
         />
       )}
     />


### PR DESCRIPTION
You can test this by adding an item to the cart going to the payment step of the checkout. Make your screen small enough so the checkboxes are not visible and click on pay without checking the checkboxes