### PR TITLE
Allow and pass HTML attributes via the Lazyhydrate component

### DIFF
--- a/.changeset/dull-goats-cheat.md
+++ b/.changeset/dull-goats-cheat.md
@@ -1,0 +1,5 @@
+---
+"@graphcommerce/next-ui": patch
+---
+
+Allow and pass HTML attributes via the Lazyhydrate component

--- a/.changeset/dull-goats-cheat.md
+++ b/.changeset/dull-goats-cheat.md
@@ -2,4 +2,4 @@
 "@graphcommerce/next-ui": patch
 ---
 
-Allow and pass HTML attributes via the Lazyhydrate component
+Update Lazyhydrate component to accept and pass HTML attributes, and replace <section> with <Box> to enable the use of all Box props on the element.

--- a/.changeset/dull-goats-cheat.md
+++ b/.changeset/dull-goats-cheat.md
@@ -1,5 +1,7 @@
 ---
-"@graphcommerce/next-ui": patch
+'@graphcommerce/next-ui': patch
 ---
 
-Update Lazyhydrate component to accept and pass HTML attributes, and replace <section> with <Box> to enable the use of all Box props on the element.
+The Lazyhydrate component to accepts any BoxProps. Replaced `<section>` with a `<Box>` so it doesn't hold symantic meaning.
+
+Please note: If you've used child selectors to style the section, please make sure you update your styles.

--- a/packages/next-ui/LazyHydrate/LazyHydrate.tsx
+++ b/packages/next-ui/LazyHydrate/LazyHydrate.tsx
@@ -1,9 +1,16 @@
-import React, { useState, useRef, startTransition, useLayoutEffect, useEffect } from 'react'
+import React, {
+  useState,
+  useRef,
+  startTransition,
+  useLayoutEffect,
+  useEffect,
+  HTMLAttributes,
+} from 'react'
 
 // Make sure the server doesn't choke on the useLayoutEffect
 export const useLayoutEffect2 = typeof window !== 'undefined' ? useLayoutEffect : useEffect
 
-export type LazyHydrateProps = {
+export type LazyHydrateProps = HTMLAttributes<HTMLElement> & {
   /**
    * The content is always rendered on the server and on the client it uses the server rendered HTML until it is hydrated.
    */
@@ -25,7 +32,7 @@ export type LazyHydrateProps = {
  * This can be a way to improve the TBT of a page.
  */
 export function LazyHydrate(props: LazyHydrateProps) {
-  const { hydrated, children } = props
+  const { hydrated, children, ...elementProps } = props
   const rootRef = useRef<HTMLElement>(null)
 
   const [isHydrated, setIsHydrated] = useState(hydrated || false)
@@ -58,15 +65,24 @@ export function LazyHydrate(props: LazyHydrateProps) {
   }, [hydrated, isHydrated])
 
   if (isHydrated) {
-    return <section>{children}</section>
+    return <section {...elementProps}>{children}</section>
   }
 
   if (typeof window === 'undefined') {
-    return <section data-lazy-hydrate>{children}</section>
+    return (
+      <section data-lazy-hydrate {...elementProps}>
+        {children}
+      </section>
+    )
   }
 
   return (
-    // eslint-disable-next-line react/no-danger
-    <section ref={rootRef} dangerouslySetInnerHTML={{ __html: '' }} suppressHydrationWarning />
+    <section
+      ref={rootRef}
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: '' }}
+      suppressHydrationWarning
+      {...elementProps}
+    />
   )
 }

--- a/packages/next-ui/LazyHydrate/LazyHydrate.tsx
+++ b/packages/next-ui/LazyHydrate/LazyHydrate.tsx
@@ -1,16 +1,10 @@
-import React, {
-  useState,
-  useRef,
-  startTransition,
-  useLayoutEffect,
-  useEffect,
-  HTMLAttributes,
-} from 'react'
+import { Box, BoxProps } from '@mui/material'
+import React, { useState, useRef, startTransition, useLayoutEffect, useEffect } from 'react'
 
 // Make sure the server doesn't choke on the useLayoutEffect
 export const useLayoutEffect2 = typeof window !== 'undefined' ? useLayoutEffect : useEffect
 
-export type LazyHydrateProps = HTMLAttributes<HTMLElement> & {
+export type LazyHydrateProps = BoxProps<'div'> & {
   /**
    * The content is always rendered on the server and on the client it uses the server rendered HTML until it is hydrated.
    */
@@ -33,7 +27,7 @@ export type LazyHydrateProps = HTMLAttributes<HTMLElement> & {
  */
 export function LazyHydrate(props: LazyHydrateProps) {
   const { hydrated, children, ...elementProps } = props
-  const rootRef = useRef<HTMLElement>(null)
+  const rootRef = useRef<HTMLDivElement>(null)
 
   const [isHydrated, setIsHydrated] = useState(hydrated || false)
   if (!isHydrated && hydrated) setIsHydrated(true)
@@ -65,19 +59,19 @@ export function LazyHydrate(props: LazyHydrateProps) {
   }, [hydrated, isHydrated])
 
   if (isHydrated) {
-    return <section {...elementProps}>{children}</section>
+    return <Box {...elementProps}>{children}</Box>
   }
 
   if (typeof window === 'undefined') {
     return (
-      <section data-lazy-hydrate {...elementProps}>
+      <Box data-lazy-hydrate {...elementProps}>
         {children}
-      </section>
+      </Box>
     )
   }
 
   return (
-    <section
+    <Box
       ref={rootRef}
       // eslint-disable-next-line react/no-danger
       dangerouslySetInnerHTML={{ __html: '' }}


### PR DESCRIPTION
There are situations where you want to add HTML attributes to the component, for example adding a  specific`class` or `ID`.
