### PR TITLE
fix: prevent rendering 'null' when method_title is not provided

### DIFF
--- a/.changeset/lucky-lizards-taste.md
+++ b/.changeset/lucky-lizards-taste.md
@@ -1,0 +1,5 @@
+---
+"@graphcommerce/magento-cart-shipping-method": patch
+---
+
+prevent rendering 'null' when method_title is not provided

--- a/packages/magento-cart-shipping-method/components/ShippingMethodForm/ShippingMethodActionCard.tsx
+++ b/packages/magento-cart-shipping-method/components/ShippingMethodForm/ShippingMethodActionCard.tsx
@@ -26,7 +26,7 @@ export function ShippingMethodActionCard(props: ShippingMethodActionCardProps) {
   const isFree = amount && amount.value === 0
 
   const title =
-    carrier_title === 'Free Shipping' ? carrier_title : `${carrier_title} ${method_title}`
+    carrier_title === 'Free Shipping' ? carrier_title : `${carrier_title} ${method_title || ''}`
 
   return (
     <ActionCard


### PR DESCRIPTION
| Before | After |
|--------|--------|
| ![image](https://github.com/graphcommerce-org/graphcommerce/assets/62989724/e1683e7e-5de5-4abc-89a5-1c77bb2021e5) | ![image](https://github.com/graphcommerce-org/graphcommerce/assets/62989724/3e996a12-4499-46a9-8e2f-96da71a644d2) | 