### PR TITLE
fix: Enable the use of one or more anchor links within the Terms and conditions label field and customize their paths. (GCOM-1384)

### DIFF
--- a/.changeset/nine-poets-appear.md
+++ b/.changeset/nine-poets-appear.md
@@ -1,0 +1,5 @@
+---
+"@graphcommerce/magento-cart": patch
+---
+
+Enable the use of one or more anchor links within the 'checkbox_text' field and customize their paths.

--- a/packages/magento-cart/components/CartAgreementsForm/CartAgreementsForm.tsx
+++ b/packages/magento-cart/components/CartAgreementsForm/CartAgreementsForm.tsx
@@ -24,10 +24,11 @@ export function CartAgreementsForm(props: CartAgreementsFormProps) {
 
   // sort conditions so checkboxes will be placed first
   const sortedAgreements = data?.checkoutAgreements
-    ? [...data.checkoutAgreements].sort((a, b) =>
-        // eslint-disable-next-line no-nested-ternary
-        a?.mode === 'MANUAL' ? -1 : b?.mode === 'MANUAL' ? 1 : 0,
-      )
+    ? [...data.checkoutAgreements]?.sort((a, b) => {
+        if (a?.mode === 'MANUAL') return -1
+        if (b?.mode === 'MANUAL') return 1
+        return 0
+      })
     : []
 
   const form = useForm()


### PR DESCRIPTION
In the current state it's not possible to insert 'custom' links into the 'checkbox_text' field.In certain scenarios, users may need to link to multiple terms and conditions (e.g. consumer or business).

| Magento | Before | After |
|--------|--------|--------|
| ![image](https://github.com/graphcommerce-org/graphcommerce/assets/62989724/7d6ebdd8-4853-4964-a2ab-5b4ceecc6e08) | ![image](https://github.com/graphcommerce-org/graphcommerce/assets/62989724/76ec999f-f556-455f-929b-9d13918f4e1c) | ![image](https://github.com/graphcommerce-org/graphcommerce/assets/62989724/180f43d4-d360-4290-97cb-683073b4365c) | 