### PR TITLE
Fixed Place order button not working (in dev mode) for certain payment methods

### DIFF
--- a/.changeset/rare-shoes-carry.md
+++ b/.changeset/rare-shoes-carry.md
@@ -1,0 +1,5 @@
+---
+"@graphcommerce/magento-payment-included": patch
+---
+
+Fixed Place order button not working (in dev mode) for certain payment methods

--- a/packages/magento-payment-included/methods.tsx
+++ b/packages/magento-payment-included/methods.tsx
@@ -1,8 +1,6 @@
-import {
-  PaymentMethodOptionsNoop,
-  PaymentMethodPlaceOrderNoop,
-  PaymentModule,
-} from '@graphcommerce/magento-cart-payment-method'
+import { PaymentModule } from '@graphcommerce/magento-cart-payment-method/Api/PaymentMethod'
+import { PaymentMethodOptionsNoop } from '@graphcommerce/magento-cart-payment-method/PaymentMethodOptionsNoop/PaymentMethodOptionsNoop'
+import { PaymentMethodPlaceOrderNoop } from '@graphcommerce/magento-cart-payment-method/PaymentMethodPlaceOrderNoop/PaymentMethodPlaceOrderNoop'
 import { ActionCard, IconSvg, iconCreditCard } from '@graphcommerce/next-ui'
 
 export const checkmo: PaymentModule = {


### PR DESCRIPTION
Place order button would show a spinner, but nothing would happen. No queries would fire. because the method `PaymentMethodPlaceOrderNoop` was undefined, due to a circular dependency