### PR TITLE
Add the possibility to place content before or after the scroller in the SidebarGallery (GCOM-1454)

### DIFF
--- a/.changeset/chilly-readers-enjoy.md
+++ b/.changeset/chilly-readers-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@graphcommerce/next-ui": patch
+---
+
+Add the possibility to place content before or after the scroller.

--- a/packages/next-ui/FramerScroller/SidebarGallery.tsx
+++ b/packages/next-ui/FramerScroller/SidebarGallery.tsx
@@ -69,6 +69,8 @@ export type SidebarGalleryProps = {
   disableZoom?: boolean
   disableSticky?: boolean
   variantMd?: SidebarGalleryVariant
+  beforeScroller?: React.ReactNode
+  afterScroller?: React.ReactNode
 } & Pick<ScrollerButtonProps, 'showButtons'>
 
 export function SidebarGallery(props: SidebarGalleryProps) {
@@ -82,6 +84,8 @@ export function SidebarGallery(props: SidebarGalleryProps) {
     disableZoom = false,
     disableSticky = false,
     variantMd = 'default',
+    beforeScroller,
+    afterScroller,
   } = props
 
   const router = useRouter()
@@ -220,6 +224,7 @@ export function SidebarGallery(props: SidebarGalleryProps) {
                 if (!zoomed) document.body.style.overflow = ''
               }}
             >
+              {beforeScroller}
               <Scroller
                 className={classes.scroller}
                 hideScrollbar
@@ -261,6 +266,7 @@ export function SidebarGallery(props: SidebarGalleryProps) {
                   />
                 ))}
               </Scroller>
+              {afterScroller}
               <MotionBox
                 layout='position'
                 layoutDependency={zoomed}


### PR DESCRIPTION
In some cases, you may want to add specific data to the SidebarGallery, such as custom labels or other information. Currently, it is only possible to send data via the children, but this data ends up in the sidebar where the product information (title, description, add to cart) is displayed.