### PR TITLE
chore: avoid displaying 'undefined' for countryName or regionName

### DIFF
--- a/.changeset/witty-carpets-flow.md
+++ b/.changeset/witty-carpets-flow.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/magento-customer': patch
+---
+
+Avoid displaying 'undefined' for countryName or regionName

--- a/packages/magento-customer/components/AddressSingleLine/AddressSingleLine.tsx
+++ b/packages/magento-customer/components/AddressSingleLine/AddressSingleLine.tsx
@@ -15,8 +15,8 @@ export function AddressSingleLine(props: CustomerAddressFragment) {
     postcode,
     country_code,
   } = props
-  const countryName = useFindCountry(country_code)?.full_name_locale
-  const regionName = typeof region === 'string' ? region : region?.region
+  const countryName = useFindCountry(country_code)?.full_name_locale ?? ''
+  const regionName = typeof region === 'string' ? region : region?.region || ''
 
   // todo: detect correct format by locale
   // for now, US format will be returned by default


### PR DESCRIPTION
**countryName**
When the page is loaded, the CountryRegions query is executed. Until then, the countryName is displayed as 'undefined'.

**regionName**
When you save an address without a 'region', it shows as 'undefined' in the `<AddressSingleLine />`. This also occurs when there is no option to fill in a 'region'.


 ![image](https://github.com/user-attachments/assets/96128b4b-a2c8-468d-a2c7-6893f4e4e4b8)