### PR TITLE
chore: add early return when there are no reviews to prevent invalid enhanced results

### DIFF
--- a/.changeset/hungry-balloons-divide.md
+++ b/.changeset/hungry-balloons-divide.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/magento-review': patch
+---
+
+Add early return when there are no reviews to prevent invalid enhanced results.

--- a/packages/magento-review/components/JsonLdProductReview/jsonLdProductReview.ts
+++ b/packages/magento-review/components/JsonLdProductReview/jsonLdProductReview.ts
@@ -6,6 +6,8 @@ export function jsonLdProductReview(
 ): Pick<Product, 'aggregateRating' | 'review'> {
   const { reviews, review_count, rating_summary } = props
 
+  if (!review_count) return {}
+
   return {
     aggregateRating: {
       '@type': 'AggregateRating',


### PR DESCRIPTION

| Error | Before | After |
|--------|--------|--------|
| ![image](https://github.com/user-attachments/assets/6dbc1f94-c18e-40f1-b7c4-758c635353d2) | ![image](https://github.com/user-attachments/assets/b6fcd20b-5ddd-4473-a7fd-554b6a8fded9) | ![image](https://github.com/user-attachments/assets/92c59574-b84c-44d2-9ad4-f528937d1fe2) | 