### PR TITLE
Handle the case where one switches from using the default .html URL suffix, to not using one

### DIFF
--- a/.changeset/healthy-lies-act.md
+++ b/.changeset/healthy-lies-act.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/magento-store': minor
+---
+
+Handle the case where one switches from using the default .html URL suffix, to not using one

--- a/packages/magento-store/utils/redirectOrNotFound.ts
+++ b/packages/magento-store/utils/redirectOrNotFound.ts
@@ -68,6 +68,11 @@ export async function redirectOrNotFound(
       candidates.add(from.endsWith(suffix) ? from.slice(0, -suffix.length) : `${from}${suffix}`)
     })
 
+    // Handle the case where we transition from using the default .html suffix, to not using one
+    if (from.endsWith('.html')) {
+      candidates.add(from.slice(0, -('.html'.length)))
+    }
+
     const routePromises = [...candidates].filter(Boolean).map(
       async (url) =>
         (


### PR DESCRIPTION
When resolving an url `foo.html` inside `redirectOrNotFound`, this change will always add `foo` to the list of candidates to look up, regardless of the current `StoreConfig.product_url_suffix` value.

This allows you to turn off the default `.html` URL suffix in Magento and still have the old URLs redirect correctly.

