### PR TITLE
Default to permanent redirects unless specified

### DIFF
--- a/.changeset/itchy-waves-brush.md
+++ b/.changeset/itchy-waves-brush.md
@@ -1,0 +1,5 @@
+---
+"@graphcommerce/magento-store": patch
+---
+
+Default to permanent redirects unless specified

--- a/packages/magento-store/utils/redirectOrNotFound.ts
+++ b/packages/magento-store/utils/redirectOrNotFound.ts
@@ -105,8 +105,8 @@ export async function redirectOrNotFound(
         ? routeData.route.relative_url
         : undefined
 
-    // There is a URL, so we need to check if it can be found in the database.
-    const permanent = routeData.route?.redirect_code === 301
+    // For implicit redirects, always use permanent, otherwise use the given redirect type
+    const permanent = !routeData.route?.redirect_code || routeData.route?.redirect_code === 301
 
     if (
       isTypename(routeData.route, [


### PR DESCRIPTION
This enhances previous PR https://github.com/graphcommerce-org/graphcommerce/pull/2373 to use a permanent redirect when this can't be determined by routeData.

I think for old .html suffix handling and /p/ redirects this is the desired behavior for SEO 🤔 