### PR TITLE
fix(custom-headers): Prevent overwriting custom context in useFormGql…

### DIFF
--- a/.changeset/chatty-melons-heal.md
+++ b/.changeset/chatty-melons-heal.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/react-hook-form': minor
+---
+
+Prevent overwriting custom context in useFormGqlMutation by merging operationOptions before execution.

--- a/packages/react-hook-form/src/useFormGql.tsx
+++ b/packages/react-hook-form/src/useFormGql.tsx
@@ -5,6 +5,7 @@ import {
   MutationTuple,
   TypedDocumentNode,
   isApolloError,
+  MutationHookOptions,
 } from '@apollo/client'
 import { getOperationName } from '@apollo/client/utilities'
 import useEventCallback from '@mui/utils/useEventCallback'
@@ -98,6 +99,7 @@ export function useFormGql<Q, V extends FieldValues>(
     document: TypedDocumentNode<Q, V>
     form: UseFormReturn<V>
     tuple: MutationTuple<Q, V> | LazyQueryResultTuple<Q, V>
+    operationOptions?: MutationHookOptions<Q, V>,
     defaultValues?: UseFormProps<V>['defaultValues']
     skipUnchanged?: boolean
   } & UseFormGraphQLCallbacks<Q, V>,
@@ -108,6 +110,7 @@ export function useFormGql<Q, V extends FieldValues>(
     document,
     form,
     tuple,
+    operationOptions,
     skipUnchanged,
     defaultValues,
     deprecated_useV1 = false,
@@ -183,7 +186,7 @@ export function useFormGql<Q, V extends FieldValues>(
       controllerRef.current = new window.AbortController()
       const result = await execute({
         variables,
-        context: { fetchOptions: { signal: controllerRef.current.signal } },
+        context: { fetchOptions: { signal: controllerRef.current.signal }, ...operationOptions?.context},
       })
 
       const [, onCompleteError] = await complete(result, variables)

--- a/packages/react-hook-form/src/useFormGql.tsx
+++ b/packages/react-hook-form/src/useFormGql.tsx
@@ -189,8 +189,8 @@ export function useFormGql<Q, V extends FieldValues>(
       controllerRef.current = new window.AbortController()
 
       const result = await execute({
-        variables,
         ...operationOptions,
+        variables,
         context: {
           ...operationOptions?.context,
           fetchOptions: {

--- a/packages/react-hook-form/src/useFormGql.tsx
+++ b/packages/react-hook-form/src/useFormGql.tsx
@@ -6,6 +6,7 @@ import {
   TypedDocumentNode,
   isApolloError,
   MutationHookOptions,
+  LazyQueryHookOptions,
 } from '@apollo/client'
 import { getOperationName } from '@apollo/client/utilities'
 import useEventCallback from '@mui/utils/useEventCallback'
@@ -99,7 +100,9 @@ export function useFormGql<Q, V extends FieldValues>(
     document: TypedDocumentNode<Q, V>
     form: UseFormReturn<V>
     tuple: MutationTuple<Q, V> | LazyQueryResultTuple<Q, V>
-    operationOptions?: MutationHookOptions<Q, V>
+    operationOptions?:
+      | Omit<MutationHookOptions<Q, V>, 'fetchPolicy' | 'variables'>
+      | Omit<LazyQueryHookOptions<Q, V>, 'fetchPolicy' | 'variables'>
     defaultValues?: UseFormProps<V>['defaultValues']
     skipUnchanged?: boolean
   } & UseFormGraphQLCallbacks<Q, V>,

--- a/packages/react-hook-form/src/useFormGql.tsx
+++ b/packages/react-hook-form/src/useFormGql.tsx
@@ -99,7 +99,7 @@ export function useFormGql<Q, V extends FieldValues>(
     document: TypedDocumentNode<Q, V>
     form: UseFormReturn<V>
     tuple: MutationTuple<Q, V> | LazyQueryResultTuple<Q, V>
-    operationOptions?: MutationHookOptions<Q, V>,
+    operationOptions?: MutationHookOptions<Q, V>
     defaultValues?: UseFormProps<V>['defaultValues']
     skipUnchanged?: boolean
   } & UseFormGraphQLCallbacks<Q, V>,
@@ -184,9 +184,17 @@ export function useFormGql<Q, V extends FieldValues>(
       submittedVariables.current = variables
       if (!deprecated_useV1 && loading) controllerRef.current?.abort()
       controllerRef.current = new window.AbortController()
+
       const result = await execute({
         variables,
-        context: { fetchOptions: { signal: controllerRef.current.signal }, ...operationOptions?.context},
+        ...operationOptions,
+        context: {
+          ...operationOptions?.context,
+          fetchOptions: {
+            ...operationOptions?.context?.fetchOptions,
+            signal: controllerRef.current.signal,
+          },
+        },
       })
 
       const [, onCompleteError] = await complete(result, variables)

--- a/packages/react-hook-form/src/useFormGqlMutation.tsx
+++ b/packages/react-hook-form/src/useFormGqlMutation.tsx
@@ -45,7 +45,7 @@ export function useFormGqlMutation<Q extends Record<string, unknown>, V extends 
 ): UseFormGqlMutationReturn<Q, V> {
   const form = useForm<V>(options)
   const tuple = useMutation(document, operationOptions)
-  const operation = useFormGql({ document, form, tuple, ...options })
+  const operation = useFormGql({ document, form, tuple, operationOptions, ...options })
   const muiRegister = useFormMuiRegister(form)
   return { ...form, ...operation, muiRegister, valid: {} }
 }

--- a/packages/react-hook-form/src/useFormGqlQuery.tsx
+++ b/packages/react-hook-form/src/useFormGqlQuery.tsx
@@ -16,7 +16,7 @@ export function useFormGqlQuery<Q extends Record<string, unknown>, V extends Fie
 ): UseFormGqlQueryReturn<Q, V> {
   const form = useForm<V>(options)
   const tuple = useLazyQuery(document, operationOptions)
-  const operation = useFormGql({ document, form, tuple, ...options })
+  const operation = useFormGql({ document, form, tuple, operationOptions, ...options })
   const muiRegister = useFormMuiRegister(form)
 
   return { ...form, ...operation, valid: {}, muiRegister }


### PR DESCRIPTION
…Mutation by merging operationOptions before execution.