### PR TITLE
chore(GCOM-1490): add ‘preventClickBack’ boolean to optionally disable back navigation

### DIFF
--- a/.changeset/fifty-moose-laugh.md
+++ b/.changeset/fifty-moose-laugh.md
@@ -3,4 +3,4 @@
 '@graphcommerce/next-ui': patch
 ---
 
-Add ‘preventClickBack’ boolean to optionally disable back navigation.
+Solve an issue where the success page would show a back button which would go back to the payment page (which would be empty)

--- a/.changeset/fifty-moose-laugh.md
+++ b/.changeset/fifty-moose-laugh.md
@@ -1,0 +1,6 @@
+---
+'@graphcommerce/magento-graphcms': patch
+'@graphcommerce/next-ui': patch
+---
+
+Add ‘preventClickBack’ boolean to optionally disable back navigation.

--- a/examples/magento-graphcms/pages/checkout/success.tsx
+++ b/examples/magento-graphcms/pages/checkout/success.tsx
@@ -40,7 +40,7 @@ function OrderSuccessPage() {
   return (
     <>
       <PageMeta title={i18n._(/* i18n */ 'Checkout summary')} metaRobots={['noindex']} />
-      <LayoutHeader floatingMd>
+      <LayoutHeader floatingMd preventClickBack>
         {hasCartId && (
           <LayoutTitle size='small' icon={iconParty}>
             <Trans id='Thank you for your order!' />

--- a/examples/magento-graphcms/pages/checkout/success.tsx
+++ b/examples/magento-graphcms/pages/checkout/success.tsx
@@ -63,7 +63,7 @@ function OrderSuccessPage() {
         )}
         {hasCartId && (
           <>
-            <LayoutTitle icon={iconParty}>
+            <LayoutTitle icon={iconParty} sx={{ flexDirection: { md: 'column' } }}>
               <Box sx={{ display: 'grid', columns: 1, justifyItems: 'center' }}>
                 <Trans id='Thank you for your order!' />
                 {orderNumber && <Typography variant='subtitle1'>#{orderNumber}</Typography>}

--- a/examples/magento-graphcms/pages/checkout/success.tsx
+++ b/examples/magento-graphcms/pages/checkout/success.tsx
@@ -40,7 +40,7 @@ function OrderSuccessPage() {
   return (
     <>
       <PageMeta title={i18n._(/* i18n */ 'Checkout summary')} metaRobots={['noindex']} />
-      <LayoutHeader floatingMd preventClickBack>
+      <LayoutHeader floatingMd disableBackNavigation>
         {hasCartId && (
           <LayoutTitle size='small' icon={iconParty}>
             <Trans id='Thank you for your order!' />

--- a/packages/next-ui/Layout/components/LayoutHeader.tsx
+++ b/packages/next-ui/Layout/components/LayoutHeader.tsx
@@ -8,7 +8,7 @@ import { FloatingProps } from './LayoutHeadertypes'
 
 export type LayoutHeaderProps = FloatingProps &
   Omit<LayoutHeaderContentProps, 'left' | 'right'> &
-  Pick<BackProps, 'preventClickBack'> & {
+  Pick<BackProps, 'disableBackNavigation'> & {
     /**
      * Button to display on the left side of the title
      *
@@ -63,7 +63,7 @@ export const LayoutHeader = React.memo<LayoutHeaderProps>((props) => {
     bgColor,
     hideSm = false,
     hideMd = false,
-    preventClickBack,
+    disableBackNavigation,
   } = props
   const showBack = useShowBack() && !hideBackButton
   const showClose = useShowClose()
@@ -80,7 +80,7 @@ export const LayoutHeader = React.memo<LayoutHeaderProps>((props) => {
   const back = showBack && (
     <LayoutHeaderBack
       breakpoint={floatingSm ? 'xs' : undefined}
-      preventClickBack={preventClickBack}
+      disableBackNavigation={disableBackNavigation}
     />
   )
 

--- a/packages/next-ui/Layout/components/LayoutHeader.tsx
+++ b/packages/next-ui/Layout/components/LayoutHeader.tsx
@@ -44,10 +44,9 @@ type ComponentStyleProps = {
   size: 'small' | 'responsive'
 }
 
-const { selectors, withState } = extendableComponent<ComponentStyleProps, 'LayoutHeader'>(
-  'LayoutHeader',
-  ['root'] as const,
-)
+const { withState } = extendableComponent<ComponentStyleProps, 'LayoutHeader'>('LayoutHeader', [
+  'root',
+] as const)
 
 export const LayoutHeader = React.memo<LayoutHeaderProps>((props) => {
   const {

--- a/packages/next-ui/Layout/components/LayoutHeader.tsx
+++ b/packages/next-ui/Layout/components/LayoutHeader.tsx
@@ -1,13 +1,14 @@
 import { Box, SxProps, Theme } from '@mui/material'
 import React from 'react'
 import { extendableComponent } from '../../Styles'
-import { LayoutHeaderBack, useShowBack } from './LayoutHeaderBack'
+import { BackProps, LayoutHeaderBack, useShowBack } from './LayoutHeaderBack'
 import { LayoutHeaderClose, useShowClose } from './LayoutHeaderClose'
 import { LayoutHeaderContent, LayoutHeaderContentProps } from './LayoutHeaderContent'
 import { FloatingProps } from './LayoutHeadertypes'
 
 export type LayoutHeaderProps = FloatingProps &
-  Omit<LayoutHeaderContentProps, 'left' | 'right'> & {
+  Omit<LayoutHeaderContentProps, 'left' | 'right'> &
+  Pick<BackProps, 'preventClickBack'> & {
     /**
      * Button to display on the left side of the title
      *
@@ -62,6 +63,7 @@ export const LayoutHeader = React.memo<LayoutHeaderProps>((props) => {
     bgColor,
     hideSm = false,
     hideMd = false,
+    preventClickBack,
   } = props
   const showBack = useShowBack() && !hideBackButton
   const showClose = useShowClose()
@@ -75,7 +77,12 @@ export const LayoutHeader = React.memo<LayoutHeaderProps>((props) => {
   if (divider || primary || secondary) floatingSm = false
 
   const close = showClose && <LayoutHeaderClose />
-  const back = showBack && <LayoutHeaderBack breakpoint={floatingSm ? 'xs' : undefined} />
+  const back = showBack && (
+    <LayoutHeaderBack
+      breakpoint={floatingSm ? 'xs' : undefined}
+      preventClickBack={preventClickBack}
+    />
+  )
 
   let left = secondary
   let right = primary

--- a/packages/next-ui/Layout/components/LayoutHeaderBack.tsx
+++ b/packages/next-ui/Layout/components/LayoutHeaderBack.tsx
@@ -13,7 +13,10 @@ import { responsiveVal } from '../../Styles'
 import { iconChevronLeft } from '../../icons'
 
 export type BackProps = Omit<LinkOrButtonProps, 'onClick' | 'children'> & {
-  preventClickBack?: boolean
+  /**
+   * Will not use `router.back()` if available, and will always use the `up.href`
+   */
+  disableBackNavigation?: boolean
 }
 
 export function useShowBack() {
@@ -40,7 +43,7 @@ const buttonSx: SxProps<Theme> = (theme) => ({
 })
 
 export function LayoutHeaderBack(props: BackProps) {
-  const { preventClickBack = false } = props
+  const { disableBackNavigation = false } = props
   const router = useRouter()
   const path = router.asPath.split('?')[0]
   const up = useUp()
@@ -49,7 +52,7 @@ export function LayoutHeaderBack(props: BackProps) {
   const prevPageRouter = usePrevPageRouter()
 
   const backIcon = <IconSvg src={iconChevronLeft} size='medium' />
-  const canClickBack = backSteps > 0 && path !== prevUp?.href && !preventClickBack
+  const canClickBack = backSteps > 0 && path !== prevUp?.href && !disableBackNavigation
 
   let label = i18n._(/* i18n */ 'Back')
   if (up?.href === path && up?.title) label = up.title

--- a/packages/next-ui/Layout/components/LayoutHeaderBack.tsx
+++ b/packages/next-ui/Layout/components/LayoutHeaderBack.tsx
@@ -12,7 +12,9 @@ import { IconSvg } from '../../IconSvg'
 import { responsiveVal } from '../../Styles'
 import { iconChevronLeft } from '../../icons'
 
-export type BackProps = Omit<LinkOrButtonProps, 'onClick' | 'children'>
+export type BackProps = Omit<LinkOrButtonProps, 'onClick' | 'children'> & {
+  preventClickBack?: boolean
+}
 
 export function useShowBack() {
   const path = useRouter().asPath.split('?')[0]
@@ -21,10 +23,7 @@ export function useShowBack() {
   const { backSteps } = usePageContext()
 
   const canClickBack = backSteps > 0 && path !== prevUp?.href
-
-  if (canClickBack) return true
-  if (up?.href && up.href !== path) return true
-  return false
+  return canClickBack || (up?.href && up.href !== path)
 }
 
 const buttonSx: SxProps<Theme> = (theme) => ({
@@ -41,6 +40,7 @@ const buttonSx: SxProps<Theme> = (theme) => ({
 })
 
 export function LayoutHeaderBack(props: BackProps) {
+  const { preventClickBack = false } = props
   const router = useRouter()
   const path = router.asPath.split('?')[0]
   const up = useUp()
@@ -49,7 +49,7 @@ export function LayoutHeaderBack(props: BackProps) {
   const prevPageRouter = usePrevPageRouter()
 
   const backIcon = <IconSvg src={iconChevronLeft} size='medium' />
-  const canClickBack = backSteps > 0 && path !== prevUp?.href
+  const canClickBack = backSteps > 0 && path !== prevUp?.href && !preventClickBack
 
   let label = i18n._(/* i18n */ 'Back')
   if (up?.href === path && up?.title) label = up.title


### PR DESCRIPTION
In some cases, you may want to force the use of the 'up' data for the 'back' button, like the checkout success page. 
This boolean ensures that the 'up' data is always used.