### PR TITLE
add disableDeselectOption boolean to prevent users from deselecting configurable options (GCOM-1507)

### DIFF
--- a/packages/ecommerce-ui/components/FormComponents/ActionCardListForm.tsx
+++ b/packages/ecommerce-ui/components/FormComponents/ActionCardListForm.tsx
@@ -4,7 +4,7 @@ import React, { MouseEventHandler } from 'react'
 
 export type ActionCardItemBase = Pick<ActionCardProps, 'value'>
 
-export type ActionCardForceSelection = { forceSelection?: boolean }
+export type ActionCardDisableDeselectOption = { disableDeselectOption?: boolean }
 
 export type ActionCardItemRenderProps<T> = ActionCardProps & {
   onReset: MouseEventHandler<HTMLElement>
@@ -17,7 +17,7 @@ export type ActionCardListFormProps<A, F extends FieldValues = FieldValues> = Om
   Omit<ControllerProps<F>, 'render'> & {
     items: A[]
     render: React.FC<ActionCardItemRenderProps<A>>
-  } & ActionCardForceSelection
+  } & ActionCardDisableDeselectOption
 
 export function ActionCardListForm<
   T extends ActionCardItemBase,
@@ -35,7 +35,7 @@ export function ActionCardListForm<
     multiple,
     disabled,
     shouldUnregister,
-    forceSelection,
+    disableDeselectOption,
     ...other
   } = props
   const RenderItem = render as React.FC<ActionCardItemRenderProps<ActionCardItemBase>>
@@ -79,7 +79,7 @@ export function ActionCardListForm<
           selected={onSelect(item.value, value)}
           onReset={(e) => {
             e.preventDefault()
-            if (!forceSelection) onChange(null)
+            if (!disableDeselectOption) onChange(null)
           }}
         />
       ))}

--- a/packages/ecommerce-ui/components/FormComponents/ActionCardListForm.tsx
+++ b/packages/ecommerce-ui/components/FormComponents/ActionCardListForm.tsx
@@ -4,6 +4,8 @@ import React, { MouseEventHandler } from 'react'
 
 export type ActionCardItemBase = Pick<ActionCardProps, 'value'>
 
+export type ActionCardForceSelection = { forceSelection?: boolean }
+
 export type ActionCardItemRenderProps<T> = ActionCardProps & {
   onReset: MouseEventHandler<HTMLElement>
 } & T
@@ -15,7 +17,7 @@ export type ActionCardListFormProps<A, F extends FieldValues = FieldValues> = Om
   Omit<ControllerProps<F>, 'render'> & {
     items: A[]
     render: React.FC<ActionCardItemRenderProps<A>>
-  }
+  } & ActionCardForceSelection
 
 export function ActionCardListForm<
   T extends ActionCardItemBase,
@@ -33,6 +35,7 @@ export function ActionCardListForm<
     multiple,
     disabled,
     shouldUnregister,
+    forceSelection,
     ...other
   } = props
   const RenderItem = render as React.FC<ActionCardItemRenderProps<ActionCardItemBase>>
@@ -76,7 +79,7 @@ export function ActionCardListForm<
           selected={onSelect(item.value, value)}
           onReset={(e) => {
             e.preventDefault()
-            onChange(null)
+            if (!forceSelection) onChange(null)
           }}
         />
       ))}

--- a/packages/magento-product-configurable/components/ConfigurableProductOptions/ConfigurableProductOptions.tsx
+++ b/packages/magento-product-configurable/components/ConfigurableProductOptions/ConfigurableProductOptions.tsx
@@ -1,4 +1,4 @@
-import { ActionCardForceSelection } from '@graphcommerce/ecommerce-ui'
+import { ActionCardDisableDeselectOption } from '@graphcommerce/ecommerce-ui'
 import { AddToCartItemSelector, useFormAddProductsToCart } from '@graphcommerce/magento-product'
 import { filterNonNullableKeys, ActionCardListProps, useLocale } from '@graphcommerce/next-ui'
 import { i18n } from '@lingui/core'
@@ -15,7 +15,7 @@ export type ConfigurableProductOptionsProps = AddToCartItemSelector & {
   render?: typeof ConfigurableOptionValue
   product: ConfigurableOptionsFragment
 } & Pick<ActionCardListProps, 'color' | 'variant' | 'size' | 'layout' | 'collapse'> &
-  ActionCardForceSelection
+  ActionCardDisableDeselectOption
 
 export function ConfigurableProductOptions(props: ConfigurableProductOptionsProps) {
   const {

--- a/packages/magento-product-configurable/components/ConfigurableProductOptions/ConfigurableProductOptions.tsx
+++ b/packages/magento-product-configurable/components/ConfigurableProductOptions/ConfigurableProductOptions.tsx
@@ -1,3 +1,4 @@
+import { ActionCardForceSelection } from '@graphcommerce/ecommerce-ui'
 import { AddToCartItemSelector, useFormAddProductsToCart } from '@graphcommerce/magento-product'
 import { filterNonNullableKeys, ActionCardListProps, useLocale } from '@graphcommerce/next-ui'
 import { i18n } from '@lingui/core'
@@ -13,7 +14,8 @@ export type ConfigurableProductOptionsProps = AddToCartItemSelector & {
   sx?: SxProps<Theme>
   render?: typeof ConfigurableOptionValue
   product: ConfigurableOptionsFragment
-} & Pick<ActionCardListProps, 'color' | 'variant' | 'size' | 'layout' | 'collapse'>
+} & Pick<ActionCardListProps, 'color' | 'variant' | 'size' | 'layout' | 'collapse'> &
+  ActionCardForceSelection
 
 export function ConfigurableProductOptions(props: ConfigurableProductOptionsProps) {
   const {


### PR DESCRIPTION
The `disableDeselectOption ` boolean can be used to ensure that users are unable to deselect options within a configurable product. By setting `disableDeselectOption ` to `true`, as in the example below, any selected option will remain selected, preventing users from accidentally or intentionally clearing their choice.

**Usage:**

 ```
<ConfigurableProductOptions product={product} disableDeselectOption />
```
