### PR TITLE
refactor: exclude ‘disableBackNavigation’ prop from LinkOrButton in LayoutHeaderBack

### DIFF
--- a/.changeset/purple-suns-unite.md
+++ b/.changeset/purple-suns-unite.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/next-ui': patch
+---
+
+Exclude ‘disableBackNavigation’ prop from LinkOrButton in LayoutHeaderBack.

--- a/packages/next-ui/Layout/components/LayoutHeaderBack.tsx
+++ b/packages/next-ui/Layout/components/LayoutHeaderBack.tsx
@@ -43,7 +43,7 @@ const buttonSx: SxProps<Theme> = (theme) => ({
 })
 
 export function LayoutHeaderBack(props: BackProps) {
-  const { disableBackNavigation = false } = props
+  const { disableBackNavigation = false, ...rest } = props
   const router = useRouter()
   const path = router.asPath.split('?')[0]
   const up = useUp()
@@ -68,7 +68,7 @@ export function LayoutHeaderBack(props: BackProps) {
         color='inherit'
         startIcon={backIcon}
         aria-label={label}
-        {...props}
+        {...rest}
       >
         <Box component='span' sx={{ display: { xs: 'none', md: 'inline' } }}>
           {label}
@@ -85,7 +85,7 @@ export function LayoutHeaderBack(props: BackProps) {
         startIcon={backIcon}
         aria-label={up.title}
         color='inherit'
-        {...props}
+        {...rest}
       >
         <Box component='span' sx={{ display: { xs: 'none', md: 'inline' } }}>
           {up.title}


### PR DESCRIPTION
Resolves the following error:
```
React does not recognize the disableBackNavigation prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase disablebacknavigation instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```