### PR TITLE
Solve an issue where image sizes are served in higher resolution than expected.

### DIFF
--- a/.changeset/gorgeous-ears-walk.md
+++ b/.changeset/gorgeous-ears-walk.md
@@ -1,0 +1,5 @@
+---
+"@graphcommerce/image": patch
+---
+
+Solve an issue where image sizes are served in higher resolution than expected.

--- a/packages/image/components/Image.tsx
+++ b/packages/image/components/Image.tsx
@@ -457,7 +457,7 @@ const Image = React.forwardRef<HTMLImageElement, ImageProps>(
       quality,
       sizes,
       width,
-      scale: 1.5,
+      scale: 2,
     })
     const srcSet2x = generateSrcSet({
       config,
@@ -467,7 +467,7 @@ const Image = React.forwardRef<HTMLImageElement, ImageProps>(
       quality,
       sizes,
       width,
-      scale: 1,
+      scale: 1.333,
     })
     const srcSet1x = generateSrcSet({
       config,


### PR DESCRIPTION
Serve smaller images by default, because there are only a list of image sizes to choose from.