### PR TITLE
refactor: Destructure InputProps to ensure they are passed only to relevant components.

### DIFF
--- a/.changeset/soft-turtles-float.md
+++ b/.changeset/soft-turtles-float.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/ecommerce-ui': patch
+---
+
+Destructure InputProps to ensure they are passed only to relevant components.

--- a/packages/ecommerce-ui/components/FormComponents/NumberFieldElement.tsx
+++ b/packages/ecommerce-ui/components/FormComponents/NumberFieldElement.tsx
@@ -36,6 +36,7 @@ export function NumberFieldElement<T extends FieldValues>(props: NumberFieldElem
     DownProps = {},
     UpProps = {},
     inputProps = {},
+    InputProps = {},
     sx = [],
     size = 'medium',
     control,
@@ -113,7 +114,7 @@ export function NumberFieldElement<T extends FieldValues>(props: NumberFieldElem
       ]}
       autoComplete='off'
       InputProps={{
-        ...textFieldProps.InputProps,
+        ...InputProps,
         startAdornment: (
           <Fab
             aria-label={i18n._(/* i18n */ 'Decrease')}


### PR DESCRIPTION
- This resolves the following error when NumberFieldElement has InputProps:

`<NumberFieldElement InputProps={{ disableUnderline: true }} />`

```
Warning: React does not recognize the `disableUnderline` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `disableunderline` instead. If you accidentally passed it from a parent component, remove it from the DOM element. Error Component Stack
```