### PR TITLE
chore: Omit disableUnderline prop for ‘outlined’ variant, because its not supported.

### DIFF
--- a/.changeset/pink-goats-shop.md
+++ b/.changeset/pink-goats-shop.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/ecommerce-ui': patch
+---
+
+Omit disableUnderline prop for ‘outlined’ variant, because its not supported.

--- a/packages/ecommerce-ui/components/FormComponents/NumberFieldElement.tsx
+++ b/packages/ecommerce-ui/components/FormComponents/NumberFieldElement.tsx
@@ -52,6 +52,13 @@ export function NumberFieldElement<T extends FieldValues>(props: NumberFieldElem
 
   const classes = withState({ size })
 
+  let InputPropsFiltered = InputProps
+
+  if (variant === 'outlined' && 'disableUnderline' in InputPropsFiltered) {
+    const { disableUnderline, ...filteredInputProps } = InputPropsFiltered
+    InputPropsFiltered = filteredInputProps
+  }
+
   if (required && !rules.required) {
     rules.required = i18n._(/* i18n */ 'This field is required')
   }
@@ -114,7 +121,7 @@ export function NumberFieldElement<T extends FieldValues>(props: NumberFieldElem
       ]}
       autoComplete='off'
       InputProps={{
-        ...InputProps,
+        ...InputPropsFiltered,
         startAdornment: (
           <Fab
             aria-label={i18n._(/* i18n */ 'Decrease')}


### PR DESCRIPTION
The `disableUnderline` prop is only available in the `Input` and `FilledInput` variants, not in `OutlinedInput`.

See docs for reference:
- [FilledInput (filled)](https://mui.com/material-ui/api/filled-input/#props)
- [OutlinedInput (outlined)](https://mui.com/material-ui/api/outlined-input/#props)
- [Input (standard)](https://mui.com/material-ui/api/input/#props)