### PR TITLE
fix(GCOM) session expired email not always available form cache

### DIFF
--- a/.changeset/olive-windows-tickle.md
+++ b/.changeset/olive-windows-tickle.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/magento-customer': patch
+---
+
+fix session expired email not always available in cache

--- a/packages/magento-customer/hooks/useAccountSignInUpForm.tsx
+++ b/packages/magento-customer/hooks/useAccountSignInUpForm.tsx
@@ -3,9 +3,9 @@ import { useQuery } from '@graphcommerce/graphql'
 import { useUrlQuery } from '@graphcommerce/next-ui'
 import { useFormGqlQuery } from '@graphcommerce/react-hook-form'
 import { useEffect } from 'react'
-import { CustomerDocument } from './Customer.gql'
 import type { IsEmailAvailableQuery, IsEmailAvailableQueryVariables } from './IsEmailAvailable.gql'
 import { IsEmailAvailableDocument } from './IsEmailAvailable.gql'
+import { UseCustomerValidateTokenDocument } from './UseCustomerValidateToken.gql'
 import { useCustomerAccountCanSignUp } from './useCustomerPermissions'
 import { useCustomerSession } from './useCustomerSession'
 
@@ -24,7 +24,7 @@ export function useAccountSignInUpForm(props: UseFormIsEmailAvailableProps = {})
 
   const [queryState, setRouterQuery] = useUrlQuery<{ email?: string | null }>()
 
-  const customerQuery = useQuery(CustomerDocument, { fetchPolicy: 'cache-only' })
+  const customerQuery = useQuery(UseCustomerValidateTokenDocument, { fetchPolicy: 'cache-only' })
   const cachedEmail = customerQuery?.data?.customer?.email
 
   const form = useFormGqlQuery<


### PR DESCRIPTION
Fix session expired email not always available in cache
- use UseCustomerValidateTokenDocument instead of CustomerDocument to find email in cache