### PR TITLE
Fixed gallery zoom breaking on long sidebar content

### DIFF
--- a/.changeset/quiet-trains-grab.md
+++ b/.changeset/quiet-trains-grab.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/next-ui': patch
+---
+
+Fixed gallery zoom breaking on long sidebar content

--- a/packages/next-ui/FramerScroller/SidebarGallery.tsx
+++ b/packages/next-ui/FramerScroller/SidebarGallery.tsx
@@ -138,6 +138,8 @@ export function SidebarGallery(props: SidebarGalleryProps) {
 
   const hasImages = images.length > 0
 
+  const sidebarSize = `calc(${responsiveVal(300, 500, undefined, theme.breakpoints.values.lg)} + ${theme.page.horizontal} * 2)`
+
   return (
     <ScrollerProvider scrollSnapAlign='center'>
       <Row
@@ -161,9 +163,7 @@ export function SidebarGallery(props: SidebarGalleryProps) {
               gridTemplate: '"left" "right"',
               [theme.breakpoints.up('md')]: {
                 '&:not(.variantMdOneColumn)': {
-                  gridTemplate: `"left right" / 1fr calc(${responsiveVal(300, 500, undefined, theme.breakpoints.values.lg)} + ${
-                    theme.page.horizontal
-                  } * 2)`,
+                  gridTemplate: `"left right" / 1fr ${sidebarSize}`,
                 },
               },
 
@@ -362,6 +362,7 @@ export function SidebarGallery(props: SidebarGalleryProps) {
             className={classes.sidebarWrapper}
             sx={[
               {
+                width: sidebarSize,
                 gridArea: 'right',
                 boxSizing: 'content-box',
                 display: 'grid',


### PR DESCRIPTION
When de sidebar contains a long (wrapped) title, the title would stretch the size of the sidebar and cause the zoomed gallery to occupy only part of the viewport instead of zooming to fullscreen