### PR TITLE
Update docs: Updated example extending GC config types

### DIFF
--- a/docs/framework/config.md
+++ b/docs/framework/config.md
@@ -71,10 +71,10 @@ You can export configuration by running `yarn graphcommerce export-config`
 Create a graphql/Config.graphqls file in your project and extend the GraphCommerceConfig, GraphCommerceStorefrontConfig inputs to add configuration.
 
 ```graphql
-extend input GraphCommerceConfig {
+input GraphCommerceConfig {
   myConfig: String # or Boolean, or Int, or Float, make required with `!`
 }
-extend input GraphCommerceStorefrontConfig {
+input GraphCommerceStorefrontConfig {
   myField: Boolean
 }
 ```


### PR DESCRIPTION
On advice from a discussion in slack after using this example, this use case actually shouldn't use `extend input` rather just `input`.

Not sure why there is a change on line 544 (just used the GitHub editor and changed code block) but if that's an issue I can get it rectified.