### PR TITLE
Resolve issue where a 400 error occurred due to missing coupon code data in the request. The coupon input field was being disabled before form submission, preventing the code from being included in the request payload

### DIFF
--- a/.changeset/odd-tomatoes-fix.md
+++ b/.changeset/odd-tomatoes-fix.md
@@ -1,0 +1,5 @@
+---
+"@graphcommerce/magento-cart-coupon": patch
+---
+
+Resolve issue where a 400 error occurred due to missing coupon code data in the request. The coupon input field was being disabled before form submission, preventing the code from being included in the request payload

--- a/packages/magento-cart-coupon/ApplyCouponForm/ApplyCouponForm.tsx
+++ b/packages/magento-cart-coupon/ApplyCouponForm/ApplyCouponForm.tsx
@@ -44,7 +44,6 @@ export function ApplyCouponForm(props: ApplyCouponFormProps) {
         rules={{ required: required.couponCode }}
         control={control}
         helperText={formState.errors.couponCode?.message}
-        disabled={formState.isSubmitting}
         showValid
       />
       <FormControl>


### PR DESCRIPTION
The cause here is identical to the previously resolved issue around logging in resolved by https://github.com/graphcommerce-org/graphcommerce/pull/2524

This PR applies the same fix here