### PR TITLE
fix: respect configurable product option positions

### DIFF
--- a/.changeset/soft-islands-hear.md
+++ b/.changeset/soft-islands-hear.md
@@ -1,0 +1,5 @@
+---
+"@graphcommerce/magento-product-configurable": patch
+---
+
+Solve issue whre Configurable Options would not respect the option position.

--- a/packages/magento-product-configurable/components/ConfigurableProductOptions/ConfigurableProductOptions.tsx
+++ b/packages/magento-product-configurable/components/ConfigurableProductOptions/ConfigurableProductOptions.tsx
@@ -65,21 +65,23 @@ export function ConfigurableProductOptions(props: ConfigurableProductOptionsProp
 
   return (
     <Box sx={(theme) => ({ display: 'grid', rowGap: theme.spacings.sm })}>
-      {options.map((option, optionIndex) => (
-        <ConfigurableProductOption
-          {...option}
-          key={option.uid}
-          render={render}
-          optionStartLabels={optionStartLabels}
-          optionEndLabels={optionEndLabels}
-          index={index}
-          optionIndex={optionIndex}
-          sx={sx}
-          __typename={product.__typename}
-          url_key={product.url_key}
-          {...other}
-        />
-      ))}
+      {options
+        .sort((a, b) => (a?.position ?? 0) - (b?.position ?? 0))
+        .map((option, optionIndex) => (
+          <ConfigurableProductOption
+            {...option}
+            key={option.uid}
+            render={render}
+            optionStartLabels={optionStartLabels}
+            optionEndLabels={optionEndLabels}
+            index={index}
+            optionIndex={optionIndex}
+            sx={sx}
+            __typename={product.__typename}
+            url_key={product.url_key}
+            {...other}
+          />
+        ))}
     </Box>
   )
 }


### PR DESCRIPTION
Fix to respect the position of configurable product options by the attribute 'position' field populated in the Magento admin

<img width="1573" height="566" alt="image" src="https://github.com/user-attachments/assets/20406dd0-5c9b-4b24-bcbe-9fb352241f75" />
