### PR TITLE
fix(magento-store): redirect product URLs without /p/ prefix to product route

### DIFF
--- a/packages/magento-store/utils/redirectOrNotFound.ts
+++ b/packages/magento-store/utils/redirectOrNotFound.ts
@@ -136,6 +136,12 @@ export async function redirectOrNotFound(
         : redirect(from, `/${redirectUrl}`, permanent, locale)
     }
 
+    // If no explicit redirect but route is a product, redirect to product route
+    if (routeData.route?.relative_url && isTypename(routeData.route, productInterfaceTypes)) {
+      const productPath = `${productRoute ?? '/p/'}${routeData.route.relative_url}`
+      return redirect(from, productPath, permanent, locale)
+    }
+
     return notFound(from, 'Route found, but no redirect URL')
   } catch (e) {
     if (e instanceof Error) {


### PR DESCRIPTION
## Summary

When visiting a product URL without the configured product route prefix (e.g., `/my-product` instead of `/p/my-product`), the `redirectOrNotFound` function returns a 404 even though Magento's route resolver successfully identifies it as a product.

### The Problem

The issue is in the redirect logic. When `relative_url === from` (which is the case when accessing `/my-product`), `redirectUrl` is `undefined`, and the code falls through to `notFound` even though:
1. A valid route was found
2. The route is identified as a product type

### The Fix

Added a check after the existing redirect logic: if no explicit redirect URL exists but the route is identified as a product type, redirect to the product route anyway.

## Test plan

- [ ] Visit a product URL without the `/p/` prefix (e.g., `/my-product-slug`)
- [ ] Verify it redirects to `/p/my-product-slug`
- [ ] Verify existing redirect behavior still works (URLs with suffixes, category redirects, etc.)
