### PR TITLE
fix: prevent sort filter from flipping direction to DESC after using the pagination

### DIFF
--- a/.changeset/puny-hounds-stare.md
+++ b/.changeset/puny-hounds-stare.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/magento-product': patch
+---
+
+Prevent sort filter from flipping direction to DESC after using the pagination

--- a/packages/magento-product/hooks/useProductListLink.ts
+++ b/packages/magento-product/hooks/useProductListLink.ts
@@ -27,7 +27,7 @@ export function productListLinkFromFilter(props: ProductFilterParams): string {
   // todo(paales): How should the URL look like with multiple sorts?
   // Something like: /sort/position,price/dir/asc,asc
   if (sort) query += `/sort/${sort}`
-  if (dir) query += '/dir/desc'
+  if (dir === 'DESC') query += '/dir/desc'
   if (pageSize) query += `/page-size/${pageSize}`
 
   // Apply filters


### PR DESCRIPTION
When using pagination with the sorting filter set to ASC, the sort direction is automatically flipped.

For example:

Using the pagination on:
https://graphcommerce.vercel.app/en-gb/search/q/sort/price

Redirects to:
https://graphcommerce.vercel.app/en-gb/search/page/2/q/sort/price/dir/desc#products