### PR TITLE
fix(magento-open-source): CMS page prerender crash from category paths

### DIFF
--- a/.changeset/fix-cms-page-prerender-open-source.md
+++ b/.changeset/fix-cms-page-prerender-open-source.md
@@ -1,0 +1,9 @@
+---
+'@graphcommerce/magento-open-source': patch
+---
+
+Fix CMS page prerender crash caused by incorrect static-paths source
+
+`pages/page/[...url].tsx` used `getCategoryStaticPaths`, which feeds Magento **category** URLs into the `cmsPage` query. Any category URL without a matching CMS page identifier caused `getStaticProps` to return a `redirect`, which Next.js rejects during prerender — crashing `next build`.
+
+The handler now returns `{ paths: [], fallback: 'blocking' }`. CMS pages render on first request and are ISR-cached afterwards.

--- a/examples/magento-open-source/pages/page/[...url].tsx
+++ b/examples/magento-open-source/pages/page/[...url].tsx
@@ -1,6 +1,5 @@
 import type { PageOptions } from '@graphcommerce/framer-next-pages'
 import { cacheFirst } from '@graphcommerce/graphql'
-import { getCategoryStaticPaths } from '@graphcommerce/magento-category'
 import type { CmsPageFragment } from '@graphcommerce/magento-cms'
 import { CmsPageContent, CmsPageDocument } from '@graphcommerce/magento-cms'
 import { PageMeta, redirectOrNotFound, StoreConfigDocument } from '@graphcommerce/magento-store'
@@ -59,13 +58,14 @@ CmsPage.pageOptions = pageOptions
 
 export default CmsPage
 
-export const getStaticPaths: GetPageStaticPaths = async ({ locales = [] }) => {
-  // Disable getStaticPaths while in development mode
-  if (process.env.NODE_ENV === 'development') return { paths: [], fallback: 'blocking' }
-
-  const path = (locale: string) => getCategoryStaticPaths(graphqlSsrClient({ locale }), locale)
-  const paths = (await Promise.all(locales.map(path))).flat(1)
-  return { paths, fallback: 'blocking' }
+export const getStaticPaths: GetPageStaticPaths = async () => {
+  // CMS pages don't currently expose a query that enumerates them, so
+  // prerender on first request via fallback: 'blocking' and let ISR cache
+  // the result. (Previously this used getCategoryStaticPaths, which fed
+  // category URLs into the cmsPage query — for any URL that didn't match a
+  // CMS page identifier, getStaticProps returned a redirect, which Next.js
+  // rejects during prerender and crashes the build.)
+  return { paths: [], fallback: 'blocking' }
 }
 
 export const getStaticProps: GetPageStaticProps = async (context) => {


### PR DESCRIPTION
## Problem

`examples/magento-open-source/pages/page/[...url].tsx` uses `getCategoryStaticPaths` to enumerate paths for the CMS page handler. That returns Magento **category** URLs, which get fed into `cmsPage(identifier: $url)`. For any URL that doesn't match a CMS page identifier (i.e. virtually all categories), `getStaticProps` returns a `redirectOrNotFound` → typically a `redirect` → Next.js rejects `redirect` from `getStaticProps` during prerender → `next build` crashes:

```
Error: `redirect` can not be returned from getStaticProps during prerendering (/page/<some-category>)
Export encountered an error on /page/[...url]: /en/page/<some-category>, exiting the build.
```

Reproducible against any Magento backend whose category set doesn't double as a CMS page set — i.e. essentially all of them.

## Fix

Return `{ paths: [], fallback: 'blocking' }`. CMS pages render on first request and are ISR-cached afterwards. There's no inexpensive query to enumerate CMS pages today, so on-demand rendering is the right semantic.

## Out of scope

The same bug exists in `examples/magento-storyblok` — fixed in a sibling PR.

## Test plan

- [ ] `next build` of `examples/magento-open-source` succeeds (was failing on any non-CMS URL fed into `/page/...`)
- [ ] Visiting `/page/<actual-cms-page>` still renders the CMS page on first request
- [ ] ISR caches the result