### PR TITLE
Fix duplicate React key warning in NumberFormat for thousands-grouped numbers

### DIFF
--- a/.changeset/fix-number-format-duplicate-integer-key.md
+++ b/.changeset/fix-number-format-duplicate-integer-key.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/next-ui': patch
+---
+
+Fix duplicate React key warning in `<NumberFormat>` / `<CurrencyFormat>` / `<Money>` for numbers with a thousands group separator. `Intl.NumberFormat.formatToParts()` emits multiple parts with `type: "integer"` (one per group, e.g. `1.234,56` produces two `integer` parts). Using `key={part.type}` therefore collided. Switched to an index key — parts are already wrapped in `suppressHydrationWarning`, so SSR/client divergence isn't an issue.

--- a/packages/next-ui/Intl/NumberFormat/NumberFormat.tsx
+++ b/packages/next-ui/Intl/NumberFormat/NumberFormat.tsx
@@ -17,8 +17,9 @@ export const NumberFormat = forwardRef<HTMLSpanElement, NumberFormatProps>((prop
 
   return (
     <Box component='span' className='NumberFormat' suppressHydrationWarning ref={ref} sx={sx}>
-      {formatter.formatToParts(value).map((part) => (
-        <span className={part.type} key={part.type} suppressHydrationWarning>
+      {formatter.formatToParts(value).map((part, i) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <span className={part.type} key={i} suppressHydrationWarning>
           {part.value}
         </span>
       ))}


### PR DESCRIPTION
## Summary

`Intl.NumberFormat.formatToParts()` emits multiple parts with `type: 'integer'` (one per thousands group). For numbers ≥ 1000 in any locale that uses a group separator (e.g. `nl-NL` formatting `1234.56` → `1.234,56`), the parts array therefore contains two items with the same `type`. Using `key={part.type}` in `NumberFormat.tsx` produced a React duplicate-key warning:

```
Encountered two children with the same key, `integer`.
```

This propagated to every consumer — `<NumberFormat>`, `<CurrencyFormat>`, `<Money>`, etc.

Switched the key to the array index. The `<span>`s are already wrapped in `suppressHydrationWarning`, so SSR/client divergence isn't a concern.

## Test plan

- [ ] Render `<Money currency="EUR" value={1234.56} />` on a `nl-NL` storefront — no console warning.
- [ ] Same with `value={123.45}` (single integer part) — still no warning.
- [ ] Same on `en-US` (`,` group) — no warning.
- [ ] Visually unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)