### PR TITLE
fix(next-config): make cleanup-interceptors actually work from consumer projects

### DIFF
--- a/.changeset/cleanup-interceptors-scan-node-modules.md
+++ b/.changeset/cleanup-interceptors-scan-node-modules.md
@@ -1,0 +1,7 @@
+---
+'@graphcommerce/next-config': patch
+---
+
+`graphcommerce cleanup-interceptors` now actually finds and restores `.original.tsx` / `.original.ts` files when run from a consumer project. Previously `findDotOriginalFiles` walked up looking for a `@graphcommerce/*` parent package; from a consumer project (where there is no such parent) `parentPath` ended up `null` and the glob expanded to literally `null/**/*.original.tsx`, so the command silently restored nothing. Now it falls back to `cwd` and `cwd/node_modules/@graphcommerce` where interceptors actually live for consumers.
+
+Also fixes a display bug — the final `X files restored from .original` line printed an always-`0` counter (`restoredCount` was declared but never incremented; the now-removed `removedCount` was the one being incremented). Counter and message are now consistent.

--- a/.changeset/signup-form-fieldsets-render-props.md
+++ b/.changeset/signup-form-fieldsets-render-props.md
@@ -1,7 +1,10 @@
 ---
 '@graphcommerce/magento-customer': minor
+'@graphcommerce/magento-store': patch
 ---
 
 `SignUpForm` now accepts `fieldsets` and `render` props (mirroring `CustomerUpdateForm`), so consumers can group dynamic customer attributes into custom labelled sections via `AttributesFormAutoLayout`. Defaults to the existing `[nameFieldset(attributes)]` / `CustomerAttributeField` behaviour, so unchanged for projects that don't supply the props.
 
 This avoids the unstyled, untranslated `Other` fallback header that `AttributesFormAutoLayout` adds whenever attributes don't fit any registered fieldset — projects that extend the customer schema (e.g. with a `club` attribute) can now declare their own fieldset alongside `nameFieldset`.
+
+The fallback header itself in `AttributesFormAutoLayout` is now wrapped in `<Trans>Other</Trans>` so it picks up project translations instead of rendering as a hardcoded English string.

--- a/.changeset/signup-form-fieldsets-render-props.md
+++ b/.changeset/signup-form-fieldsets-render-props.md
@@ -8,3 +8,5 @@
 This avoids the unstyled, untranslated `Other` fallback header that `AttributesFormAutoLayout` adds whenever attributes don't fit any registered fieldset — projects that extend the customer schema (e.g. with a `club` attribute) can now declare their own fieldset alongside `nameFieldset`.
 
 The fallback header itself in `AttributesFormAutoLayout` is now wrapped in `<Trans>Other</Trans>` so it picks up project translations instead of rendering as a hardcoded English string.
+
+Bug fix in `nameFieldset`: when a store doesn't register `dob`/`gender` on the registration form, the `additional` row was empty and the helper produced `grid-template-areas: "firstname lastname" ""`, which is invalid CSS and made the whole declaration fall back to the default single-column layout — firstname/lastname stacked on separate rows even at md+. Empty rows are now filtered out, so the side-by-side md layout works as intended.

--- a/.changeset/signup-form-fieldsets-render-props.md
+++ b/.changeset/signup-form-fieldsets-render-props.md
@@ -1,0 +1,7 @@
+---
+'@graphcommerce/magento-customer': minor
+---
+
+`SignUpForm` now accepts `fieldsets` and `render` props (mirroring `CustomerUpdateForm`), so consumers can group dynamic customer attributes into custom labelled sections via `AttributesFormAutoLayout`. Defaults to the existing `[nameFieldset(attributes)]` / `CustomerAttributeField` behaviour, so unchanged for projects that don't supply the props.
+
+This avoids the unstyled, untranslated `Other` fallback header that `AttributesFormAutoLayout` adds whenever attributes don't fit any registered fieldset — projects that extend the customer schema (e.g. with a `club` attribute) can now declare their own fieldset alongside `nameFieldset`.

--- a/packages/magento-customer/components/CustomerForms/nameFieldset.tsx
+++ b/packages/magento-customer/components/CustomerForms/nameFieldset.tsx
@@ -19,13 +19,21 @@ export function nameFieldset(
 
   const additional = extractAttributes(attributes, ['dob', 'gender'])[0].map((f) => f.code)
 
+  // Skip empty rows — an empty `""` row produces invalid `grid-template-areas`
+  // and silently makes the whole declaration fall back to the default
+  // single-column layout. Hit when a store doesn't register `dob`/`gender` on
+  // the registration form, leaving `additional` empty.
+  const rows = [nameFields, additional]
+    .filter((row) => row.length > 0)
+    .map((row) => `"${row.join(' ')}"`)
+
   return {
     label: withLabel ? <Trans>Name</Trans> : undefined,
     gridAreas: [...nameFields, ...additional],
     // xs is shown in one column by default
     sx: {
       gridTemplateAreas: {
-        md: [`"${nameFields.join(' ')}"`, `"${additional.join(' ')}"`].join(' '),
+        md: rows.join(' '),
       },
     },
   }

--- a/packages/magento-customer/components/SignUpForm/SignUpForm.tsx
+++ b/packages/magento-customer/components/SignUpForm/SignUpForm.tsx
@@ -1,6 +1,10 @@
 import { FormPersist, PasswordRepeatElement, SwitchElement } from '@graphcommerce/ecommerce-ui'
 import { useQuery } from '@graphcommerce/graphql'
-import { AttributesFormAutoLayout, StoreConfigDocument } from '@graphcommerce/magento-store'
+import {
+  AttributesFormAutoLayout,
+  StoreConfigDocument,
+  type AttributeFormAutoLayoutProps,
+} from '@graphcommerce/magento-store'
 import { magentoVersion } from '@graphcommerce/next-config/config'
 import { Button, FormActions, FormRow } from '@graphcommerce/next-ui'
 import type { UseFormClearErrors, UseFormSetError } from '@graphcommerce/react-hook-form'
@@ -11,18 +15,24 @@ import { useSignInForm } from '../../hooks/useSignInForm'
 import { ApolloCustomerErrorSnackbar } from '../ApolloCustomerError/ApolloCustomerErrorSnackbar'
 import { CustomerAttributeField } from '../CustomerForms/CustomerAttributeField'
 import { nameFieldset } from '../CustomerForms/nameFieldset'
-import { useCustomerCreateForm } from '../CustomerForms/useCustomerCreateForm'
+import {
+  useCustomerCreateForm,
+  type CreateCustomerFormValues,
+} from '../CustomerForms/useCustomerCreateForm'
 import { NameFields } from '../NameFields/NameFields'
 import { ValidatedPasswordElement } from '../ValidatedPasswordElement/ValidatedPasswordElement'
 
-type SignUpFormProps = {
+export type SignUpFormProps = Pick<
+  AttributeFormAutoLayoutProps<CreateCustomerFormValues, 'CustomerAttributeMetadata'>,
+  'fieldsets' | 'render'
+> & {
   email?: string
   setError: UseFormSetError<{ email?: string; requestedMode?: 'signin' | 'signup' }>
   clearErrors: UseFormClearErrors<{ email?: string; requestedMode?: 'signin' | 'signup' }>
 }
 
 export function SignUpForm(props: SignUpFormProps) {
-  const { email, setError, clearErrors } = props
+  const { email, setError, clearErrors, fieldsets, render } = props
 
   const storeConfig = useQuery(StoreConfigDocument)
 
@@ -109,8 +119,8 @@ export function SignUpForm(props: SignUpFormProps) {
         <AttributesFormAutoLayout
           attributes={attributes}
           control={control}
-          render={CustomerAttributeField}
-          fieldsets={[nameFieldset(attributes)]}
+          render={render ?? CustomerAttributeField}
+          fieldsets={fieldsets ?? [nameFieldset(attributes)]}
         />
       )}
 

--- a/packages/magento-store/components/AttributeForm/AttributesFormAutoLayout.tsx
+++ b/packages/magento-store/components/AttributeForm/AttributesFormAutoLayout.tsx
@@ -5,6 +5,7 @@ import {
   type SectionContainerProps,
 } from '@graphcommerce/next-ui'
 import type { Control, FieldValues } from '@graphcommerce/react-hook-form'
+import { Trans } from '@lingui/react/macro'
 import { Box, type SxProps, type Theme } from '@mui/material'
 import { AttributeFormField, type AttributeFormFieldProps } from './AttributeFormField'
 import type {
@@ -54,7 +55,8 @@ export function AttributesFormAutoLayout<
       .filter(nonNullable),
   }))
 
-  if (itemsRemaining.length > 0) byFieldSet.push({ label: 'Other', attributes: itemsRemaining })
+  if (itemsRemaining.length > 0)
+    byFieldSet.push({ label: <Trans>Other</Trans>, attributes: itemsRemaining })
 
   return byFieldSet.map((fieldSet) => {
     const key = fieldSet.attributes.map((fieldName) => fieldName.gridArea).join('-')

--- a/packagesDev/next-config/__tests__/interceptors/generateInterceptors.ts
+++ b/packagesDev/next-config/__tests__/interceptors/generateInterceptors.ts
@@ -75,7 +75,8 @@ it('it generates an interceptor', async () => {
     type PluginAddMollieMethodsProps = OmitPrev<
       React.ComponentProps<typeof PluginAddMollieMethods>,
       'Prev'
-    >
+    > &
+      PluginAddBraintreeMethodsProps
 
     const PluginAddMollieMethodsInterceptor = (props: PluginAddMollieMethodsProps) => (
       <PluginAddMollieMethods {...props} Prev={PluginAddBraintreeMethodsInterceptor} />
@@ -91,7 +92,9 @@ it('it generates an interceptor', async () => {
      * @see {PluginAddBraintreeMethods} for source of applied plugin
      * @see {PluginAddMollieMethods} for source of applied plugin
      */
-    export const PaymentMethodContextProvider = PluginAddMollieMethodsInterceptor
+    export const PaymentMethodContextProvider =
+      PluginAddMollieMethodsInterceptor as typeof PaymentMethodContextProviderOriginal &
+        React.FC<PluginAddMollieMethodsProps>
     "
   `)
 })
@@ -176,7 +179,8 @@ it('it can apply multiple plugins to a single export', async () => {
     type PluginAddMollieMethodsProps = OmitPrev<
       React.ComponentProps<typeof PluginAddMollieMethods>,
       'Prev'
-    >
+    > &
+      PluginAddAdyenMethodsProps
 
     const PluginAddMollieMethodsInterceptor = (props: PluginAddMollieMethodsProps) => (
       <PluginAddMollieMethods {...props} Prev={PluginAddAdyenMethodsInterceptor} />
@@ -192,7 +196,9 @@ it('it can apply multiple plugins to a single export', async () => {
      * @see {PluginAddAdyenMethods} for source of applied plugin
      * @see {PluginAddMollieMethods} for source of applied plugin
      */
-    export const PaymentMethodContextProvider = PluginAddMollieMethodsInterceptor
+    export const PaymentMethodContextProvider =
+      PluginAddMollieMethodsInterceptor as typeof PaymentMethodContextProviderOriginal &
+        React.FC<PluginAddMollieMethodsProps>
     "
   `)
 })
@@ -245,7 +251,8 @@ it('it handles on duplicates gracefully', async () => {
     type PluginAddBraintreeMethodsProps = OmitPrev<
       React.ComponentProps<typeof PluginAddBraintreeMethods>,
       'Prev'
-    >
+    > &
+      PluginAddBraintreeMethodsProps
 
     const PluginAddBraintreeMethodsInterceptor = (props: PluginAddBraintreeMethodsProps) => (
       <PluginAddBraintreeMethods {...props} Prev={PluginAddBraintreeMethodsInterceptor} />
@@ -261,7 +268,9 @@ it('it handles on duplicates gracefully', async () => {
      * @see {PluginAddBraintreeMethods} for source of applied plugin
      * @see {PluginAddBraintreeMethods} for source of applied plugin
      */
-    export const PaymentMethodContextProvider = PluginAddBraintreeMethodsInterceptor
+    export const PaymentMethodContextProvider =
+      PluginAddBraintreeMethodsInterceptor as typeof PaymentMethodContextProviderOriginal &
+        React.FC<PluginAddBraintreeMethodsProps>
     "
   `)
 })
@@ -636,7 +645,9 @@ export const Plugin = ConfigurableProductPageName
      * @see {ProductPageNameMyPlugin} for source of replaced component
      * @see {PluginConfigurableProductPageName} for source of applied plugin
      */
-    export const ProductPageName = PluginConfigurableProductPageNameInterceptor
+    export const ProductPageName =
+      PluginConfigurableProductPageNameInterceptor as typeof ProductPageNameMyPlugin &
+        React.FC<PluginConfigurableProductPageNameProps>
     "
   `)
 })

--- a/packagesDev/next-config/dist/index.js
+++ b/packagesDev/next-config/dist/index.js
@@ -52,9 +52,12 @@ async function findDotOriginalFiles(cwd) {
     if (p) parentPath = p;
     else break;
   }
-  return Promise.all(
-    (await glob([`${parentPath}/**/*.original.tsx`, `${parentPath}/**/*.original.ts`], { cwd })).map((file) => fs.realpath(file))
-  );
+  const roots = parentPath ? [parentPath] : [cwd, `${cwd}/node_modules/@graphcommerce`];
+  const patterns = roots.flatMap((root) => [
+    `${root}/**/*.original.tsx`,
+    `${root}/**/*.original.ts`
+  ]);
+  return Promise.all((await glob(patterns, { cwd })).map((file) => fs.realpath(file)));
 }
 async function writeInterceptors(interceptors, cwd = process.cwd()) {
   const processedFiles = [];
@@ -105,13 +108,12 @@ dotenv.config({ quiet: true });
 async function cleanupInterceptors(cwd = process.cwd()) {
   console.info("\u{1F9F9} Starting interceptor cleanup...");
   let restoredCount = 0;
-  let removedCount = 0;
   const originalFiles = await findDotOriginalFiles(cwd);
   console.info(`\u{1F4C2} Found ${originalFiles.length} .original files to restore`);
   for (const originalFile of originalFiles) {
     try {
       await restoreOriginalFile(originalFile);
-      removedCount++;
+      restoredCount++;
     } catch (error) {
       console.error(`\u274C Failed to restore ${originalFile}:`, error);
     }

--- a/packagesDev/next-config/src/commands/cleanupInterceptors.ts
+++ b/packagesDev/next-config/src/commands/cleanupInterceptors.ts
@@ -7,7 +7,6 @@ export async function cleanupInterceptors(cwd: string = process.cwd()) {
   console.info('🧹 Starting interceptor cleanup...')
 
   let restoredCount = 0
-  let removedCount = 0
 
   const originalFiles = await findDotOriginalFiles(cwd)
   console.info(`📂 Found ${originalFiles.length} .original files to restore`)
@@ -15,7 +14,7 @@ export async function cleanupInterceptors(cwd: string = process.cwd()) {
   for (const originalFile of originalFiles) {
     try {
       await restoreOriginalFile(originalFile)
-      removedCount++
+      restoredCount++
     } catch (error) {
       console.error(`❌ Failed to restore ${originalFile}:`, error)
     }

--- a/packagesDev/next-config/src/interceptors/writeInterceptors.ts
+++ b/packagesDev/next-config/src/interceptors/writeInterceptors.ts
@@ -40,11 +40,18 @@ export async function findDotOriginalFiles(cwd: string) {
     else break
   }
 
-  return Promise.all(
-    (
-      await glob([`${parentPath}/**/*.original.tsx`, `${parentPath}/**/*.original.ts`], { cwd })
-    ).map((file) => fs.realpath(file)),
-  )
+  // Called from inside a @graphcommerce package (upstream dev) → scan from the
+  // outermost @graphcommerce parent. Called from a consumer project (no
+  // @graphcommerce parent) → scan the project AND node_modules/@graphcommerce,
+  // because the interceptor system writes .original files alongside the
+  // installed packages there.
+  const roots = parentPath ? [parentPath] : [cwd, `${cwd}/node_modules/@graphcommerce`]
+  const patterns = roots.flatMap((root) => [
+    `${root}/**/*.original.tsx`,
+    `${root}/**/*.original.ts`,
+  ])
+
+  return Promise.all((await glob(patterns, { cwd })).map((file) => fs.realpath(file)))
 }
 
 export async function writeInterceptors(


### PR DESCRIPTION
## Summary

Two small bugs in `graphcommerce cleanup-interceptors`:

1. **`findDotOriginalFiles` never found anything from a consumer project.** The function walked up the tree looking for a `@graphcommerce/*` parent package; from a consumer project (where there is no such parent) `parentPath` ended up `null` and the glob expanded to literally `null/**/*.original.tsx` — silently finding zero files no matter how many interceptors were on disk. Now falls back to `cwd` and `cwd/node_modules/@graphcommerce` when there's no `@graphcommerce` parent, so interceptors written into the consumer's `node_modules` get picked up.
2. **`X files restored from .original` always printed `0`.** `restoredCount` was declared but never incremented; the now-removed `removedCount` was the one being incremented. Counter and message are now consistent.

## Why

Consumer projects use `yarn graphcommerce cleanup-interceptors` (often chained before `patch-package` via `yarn create-patch`) to get `node_modules/@graphcommerce/*` back to canary state before generating a patch. With the old `findDotOriginalFiles` the script was a no-op in that flow — patches ended up including all the locally-written interceptor wrappers and `.original` files, polluting the diff with framework-generated state.

## Test plan

- [ ] From a consumer project with active plugins (so `node_modules/@graphcommerce/*` contains `.original.tsx` files), `yarn graphcommerce cleanup-interceptors` reports the actual count and restores them
- [ ] From an upstream `@graphcommerce/*` package, behaviour is unchanged (uses the `parentPath` walk)
- [ ] Counter in the final message matches the number of files actually restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)