### PR TITLE
fix(magento-store): allow empty/false custom-attribute values to pass through

### DIFF
--- a/.changeset/attribute-value-inputs-allow-clearing.md
+++ b/.changeset/attribute-value-inputs-allow-clearing.md
@@ -1,0 +1,7 @@
+---
+'@graphcommerce/magento-store': patch
+---
+
+`CustomAttributesField_to_AttributeValueInputs` was filtering out any falsy form value (`if (!value) return`), so empty strings and `false` booleans never made it into the resulting `AttributeValueInput[]`. That meant a consumer who picked the empty-string option of a SELECT attribute (e.g. a "-- None --" option used to undo a previous choice) couldn't actually clear the attribute — the mutation simply omitted it and Magento kept the old value.
+
+Skip only when the value is `undefined` (the attribute was never touched). Pass empty strings and `false` booleans through to the mutation so the backend can interpret them as "clear this attribute".

--- a/packages/magento-store/components/AttributeForm/useAttributesForm.tsx
+++ b/packages/magento-store/components/AttributeForm/useAttributesForm.tsx
@@ -106,7 +106,12 @@ export function CustomAttributesField_to_AttributeValueInputs(
     const attribute_code = metadata.code
     const value = custom_attributes[metadata.code]
 
-    if (!value) return
+    // Only skip when the form field was never set. Empty strings and `false`
+    // booleans must pass through so the backend can interpret them as
+    // "clear this attribute" — otherwise the consumer has no way to undo a
+    // previously-selected value via the form (e.g. a "-- None --" SELECT
+    // option whose value is the empty string).
+    if (value === undefined) return
 
     if (
       (metadata.__typename === 'CustomerAttributeMetadata' &&


### PR DESCRIPTION
## Summary

`CustomAttributesField_to_AttributeValueInputs` filtered out any falsy form value with `if (!value) return`, so:

- An empty-string option in a SELECT attribute (the canonical "-- None --" / "-- Geen … --" pattern used to undo a previous choice) never reached the mutation — Magento kept the old value.
- A BOOLEAN attribute the consumer unchecks after previously checking it — same story, the `false` value got swallowed.

Skip only when the value is `undefined` (the attribute was never touched on the form). Pass empty strings and `false` booleans through so the backend can interpret them as "clear this attribute".

## Why

The Magento `updateCustomerV2` mutation handles `value: ""` correctly when the consuming module's data patch is set up for it (Reach Digital's clubportaal module does exactly this in jumbosports — empty string from the SELECT clears the `club` customer attribute, full URL on first set). The bug was that the storefront never sent the empty value through, so the user's "-- None --" choice silently no-op'd.

## Test plan

- [ ] Pick an attribute exposing a "-- None --" option whose value is `''`, change from a non-empty value back to that option, save → the mutation includes `{ attribute_code: "<code>", value: "" }` and Magento clears the attribute
- [ ] Toggle off a BOOLEAN custom attribute the customer previously had checked → mutation includes `{ attribute_code: "<code>", value: "0" }`
- [ ] An attribute the user never touched still gets omitted from the mutation (unchanged behaviour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)