### PR TITLE
docs: document the playwright e2e workflow

### DIFF
--- a/.changeset/document-playwright-workflow.md
+++ b/.changeset/document-playwright-workflow.md
@@ -1,0 +1,11 @@
+---
+'@graphcommerce/misc': patch
+---
+
+Document the Playwright e2e workflow in CLAUDE.md: where tests live
+(`<pkg>/test/*.playwright.ts`), how to install the browser binaries,
+the `URL` / `PLAYWRIGHT_LOCALES` env vars exposed by
+`playwright.config.ts`, and the backend assumptions tests make
+(GraphCommerce demo backend). Picks up the loose ends from
+graphcommerce-org/graphcommerce#2627 which fixed the config so
+`npx playwright test` actually loads.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,8 +93,53 @@ yarn test packages/foo       # Run tests matching a path
 ```
 
 Tests use Vitest with
-`include: ['**/__tests__/**/*.ts', '**/*.test.ts', '**/*.test.tsx']`. E2E tests
-use Playwright: `yarn playwright`.
+`include: ['**/__tests__/**/*.ts', '**/*.test.ts', '**/*.test.tsx']`.
+
+#### Playwright (E2E)
+
+End-to-end tests live next to the package they exercise, named
+`<feature>.playwright.ts` (e.g.
+`packages/magento-product/test/youtubeEmbedInGallery.playwright.ts`,
+`packages/magento-customer/test/authentication.playwright.ts`). They're
+picked up by `playwright.config.ts` via `testMatch: ['**/*.playwright.ts']`
+and they exercise a real running example storefront — there is no jsdom,
+no mocked Apollo cache.
+
+One-time setup (only needed if you've never run Playwright on this machine
+or the browsers are stale):
+
+```bash
+npx playwright install chromium   # or `npx playwright install` for all browsers
+```
+
+Day-to-day workflow:
+
+```bash
+# Terminal A — start the storefront the test will hit
+yarn workspace @graphcommerce/magento-graphcms dev
+
+# Terminal B — run the suite (default project is chrome, headed)
+yarn playwright
+# Or a single test, headless, with a non-default port / URL:
+URL=http://localhost:3210 npx playwright test \
+  packages/magento-product/test/youtubeEmbedInGallery.playwright.ts \
+  --project=chrome --reporter=line
+```
+
+- `URL` overrides the `baseURL` for every test (`page.goto('/p/foo')`
+  resolves against `$URL/p/foo`).
+- `PLAYWRIGHT_LOCALES=nl,de` generates extra `<project>-<locale>` projects
+  that target `$URL/<locale>` — opt-in only because most tests are
+  locale-agnostic.
+- `test-results/` and `playwright-report/` are gitignored — both are local
+  artifacts that the runner regenerates on every invocation.
+
+Backend assumptions: tests run against the Magento endpoint configured in
+`examples/magento-graphcms/graphcommerce.config.ts`. They hardcode SKUs /
+URL keys that are present in the GraphCommerce demo backend
+(`configurator.reachdigital.dev`); when running against a different backend
+either override via env vars (the gallery test reads `PRODUCT_URL` and
+`EXPECTED_YOUTUBE_ID`) or skip backend-specific tests.
 
 ### Linting & Type Checking
 


### PR DESCRIPTION
## Summary

Picks up the loose ends from #2627 which fixed `playwright.config.ts` so `npx playwright test` actually loads. The existing CLAUDE.md only mentioned Playwright in a single sentence (\`E2E tests use Playwright: \`yarn playwright\`\`) — it didn't say:

- where tests live (`packages/<pkg>/test/<feature>.playwright.ts`, picked up via `testMatch: ['**/*.playwright.ts']`)
- that browser binaries need installing once (`npx playwright install chromium`)
- that tests need a running storefront in another terminal
- the `URL` env var for non-default ports / backends
- the new `PLAYWRIGHT_LOCALES=nl,de` opt-in env var added in #2627
- that `test-results/` and `playwright-report/` are gitignored local artifacts

Expand the Testing section so a new contributor can actually run the suite, and so it's clear that adding new tests means dropping a `<feature>.playwright.ts` next to the package.

## Test plan

- [x] CLAUDE.md renders correctly on GitHub.
- [x] No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)