### PR TITLE
test(next-config): regenerate mergeEnvIntoConfig snapshot to unblock CI

### DIFF
--- a/.changeset/fix-merge-env-snapshot.md
+++ b/.changeset/fix-merge-env-snapshot.md
@@ -1,0 +1,11 @@
+---
+'@graphcommerce/next-config': patch
+---
+
+Regenerate the `mergeEnvIntoConfig` snapshot so `yarn test` passes on
+canary. The test input already feeds `GC_DEMO_MODE` and
+`GC_STOREFRONT_<i>_HYGRAPH_LOCALES_0` into the env-schema parser, but
+the snapshot it was compared against still reflected the pre-`demoMode`
+/ pre-flattened-`hygraphLocales` schema, so every CI run since those
+config fields were added has been failing the `test` job on every PR
+with a snapshot mismatch unrelated to the PR's own changes.

--- a/packagesDev/next-config/__tests__/config/utils/__snapshots__/mergeEnvIntoConfig.ts.snap
+++ b/packagesDev/next-config/__tests__/config/utils/__snapshots__/mergeEnvIntoConfig.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`parses an env config object 1`] = `
 {
+  "GC_DEMO_MODE": true,
   "GC_STOREFRONT": [
     {
       "defaultLocale": true,
@@ -13,8 +14,10 @@ exports[`parses an env config object 1`] = `
     },
   ],
   "GC_STOREFRONT_0_DEFAULT_LOCALE": true,
+  "GC_STOREFRONT_0_HYGRAPH_LOCALES_0": "en",
   "GC_STOREFRONT_0_LOCALE": "en",
   "GC_STOREFRONT_0_MAGENTO_STORE_CODE": "en_us",
+  "GC_STOREFRONT_1_HYGRAPH_LOCALES_0": "de",
   "GC_STOREFRONT_1_LOCALE": "de",
   "GC_STOREFRONT_1_MAGENTO_STORE_CODE": "de_de",
 }


### PR DESCRIPTION
## Summary

Every PR's `pr-analysis / test` job has been failing on canary with a snapshot mismatch in `mergeEnvIntoConfig` — unrelated to the PR's own changes. Example: latest run on #2628 https://github.com/graphcommerce-org/graphcommerce/actions/runs/26162186314/job/76978986351 ends with:

```
Snapshot \`parses an env config object 1\` mismatched

- Expected
+ Received

+   "GC_DEMO_MODE": true,
    "GC_STOREFRONT": [ … hygraphLocales: ["en"] … ],
    "GC_STOREFRONT_0_DEFAULT_LOCALE": true,
+   "GC_STOREFRONT_0_HYGRAPH_LOCALES_0": "en",
    "GC_STOREFRONT_0_LOCALE": "en",
    "GC_STOREFRONT_0_MAGENTO_STORE_CODE": "en_us",
+   "GC_STOREFRONT_1_HYGRAPH_LOCALES_0": "de",
    "GC_STOREFRONT_1_LOCALE": "de",
    "GC_STOREFRONT_1_MAGENTO_STORE_CODE": "de_de",
  }

 ❯ packagesDev/next-config/__tests__/config/utils/mergeEnvIntoConfig.ts:48:18
```

Root cause: the test input at `mergeEnvIntoConfig.ts:21-34` was updated to include `GC_DEMO_MODE`, `GC_STOREFRONT_0_HYGRAPH_LOCALES_0`, and `GC_STOREFRONT_1_HYGRAPH_LOCALES_0` when those fields landed in the config schema, but the committed snapshot was never regenerated. The env-schema parser correctly emits those three extra keys; the snapshot just doesn't expect them.

This PR only updates the snapshot to match the schema. No code change, no behaviour change, no other tests touched. Once merged, every other PR's `test` job goes green without rebasing.

## Test plan

- [x] Snapshot diff matches the runtime output exactly as reported by the CI failure.
- [ ] `pr-analysis / test` passes on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)