### PR TITLE
fix(next-ui): scope MuiFabSizes width/height to circular Fabs

### DIFF
--- a/.changeset/fix-fab-extended-width.md
+++ b/.changeset/fix-fab-extended-width.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/next-ui': patch
+---
+
+Fix: `<Fab variant="extended">` no longer gets a fixed `width` from `MuiFabSizes`. The size-based width/height variants are now scoped to `variant: 'circular'` only, so extended Fabs can grow with their label (controlled via `min-width` instead) as MUI intends. Previously every extended Fab without an explicit `size` matched the default `large` rule and was forced to 54px wide.

--- a/packages/next-ui/Theme/MuiFab.ts
+++ b/packages/next-ui/Theme/MuiFab.ts
@@ -80,11 +80,14 @@ const sizes: FabSize[] = [
 /**
  * This defines the sizes for the added responsive variant.
  *
+ * Only applied to circular (default) Fabs — extended Fabs must keep `width: auto` and rely on their
+ * content + `min-width`, otherwise they collapse to a fixed square regardless of label.
+ *
  * To override the sizes, please do not add variant declarations direcly, but modify
  * `yourTheme.components.MuiFabExtra.sizes` instead.
  */
 export const MuiFabSizes: FabVariants = sizes.map((size) => ({
-  props: { size },
+  props: { size, variant: 'circular' },
   style: ({ theme }) => fabWidthHeight(size, theme),
 }))
 


### PR DESCRIPTION
## Summary

`MuiFabSizes` in `packages/next-ui/Theme/MuiFab.ts` applies `width` + `height` for every supported Fab `size`, but does not filter on `variant`. The default Fab size is `large` (54px), so every `<Fab variant="extended">` rendered without an explicit `size` matches the `large` variant rule and gets `width: 54px, height: 54px` — collapsing extended Fabs to a fixed square regardless of their label. Consumer-side `minWidth` overrides lose the specificity battle against MUI's variant rules.

This scopes the size variants to `variant: 'circular'` so that:

- Circular Fabs continue to get the framework's responsive size table.
- Extended Fabs grow with their label (MUI's intent: `width: auto` + a `min-width` floor controlled by the consumer).

## Test plan

- [ ] `<Fab variant="extended">Customize</Fab>` without `size` now renders pill-shaped, not a square.
- [ ] `<Fab size="responsive">` (circular, default variant) keeps its responsive width/height.
- [ ] Existing storefronts using circular Fabs are unaffected.