### PR TITLE
Sync Storyblok content with the Visual Editor's selected language

### DIFF
--- a/.changeset/flat-pumas-love.md
+++ b/.changeset/flat-pumas-love.md
@@ -1,0 +1,8 @@
+---
+'@graphcommerce/magento-open-source': patch
+'@graphcommerce/magento-storyblok': patch
+'@graphcommerce/magento-graphcms': patch
+'@graphcommerce/graphql': patch
+---
+
+Make GraphCommerce compatible with Apollo Client 4.2+ by augmenting Apollo's `DefaultOptions` type with the `preview` extension and the SSR clients' `errorPolicy: 'all'` default.

--- a/.changeset/long-buttons-begin.md
+++ b/.changeset/long-buttons-begin.md
@@ -1,0 +1,6 @@
+---
+'@graphcommerce/magento-storyblok': patch
+'@graphcommerce/storyblok-ui': patch
+---
+
+Sync Storyblok content with the Visual Editor's selected language

--- a/examples/magento-graphcms/lib/graphql/graphqlSsrClient.ts
+++ b/examples/magento-graphcms/lib/graphql/graphqlSsrClient.ts
@@ -37,7 +37,7 @@ function client(context: GetStaticPropsContext, fetchPolicy: FetchPolicy = 'no-c
     defaultOptions: {
       preview: context as PreviewConfig,
       query: { errorPolicy: 'all', fetchPolicy },
-    } as ApolloClient.DefaultOptions,
+    },
   })
 }
 

--- a/examples/magento-open-source/lib/graphql/graphqlSsrClient.ts
+++ b/examples/magento-open-source/lib/graphql/graphqlSsrClient.ts
@@ -36,7 +36,7 @@ function client(context: GetStaticPropsContext, fetchPolicy: FetchPolicy = 'no-c
     defaultOptions: {
       preview: context as PreviewConfig,
       query: { errorPolicy: 'all', fetchPolicy },
-    } as ApolloClient.DefaultOptions,
+    },
   })
 }
 

--- a/examples/magento-storyblok/components/Storyblok/GlobalConfigProvider.tsx
+++ b/examples/magento-storyblok/components/Storyblok/GlobalConfigProvider.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useEffect, useState } from 'react'
+import { fetchGlobalConfig, useEditorState } from '../../lib/storyblok'
 import type { StoryblokGlobalConfig } from './types'
 
 const GlobalConfigContext = createContext<StoryblokGlobalConfig | null>(null)
@@ -11,9 +12,11 @@ export function GlobalConfigProvider(props: {
   children: React.ReactNode
 }) {
   const { value, children } = props
+  const { skip, editorLanguage } = useEditorState()
 
-  // `override` holds live Visual Editor updates pushed via `useSetGlobalConfig`.
-  // When unset (null), we fall back to the SSR `value` prop.
+  // `override` holds live Visual Editor updates pushed via `useSetGlobalConfig`
+  // and editor-language refetches done below. When unset, we fall back to the
+  // SSR `value` prop.
   const [override, setOverride] = useState<StoryblokGlobalConfig | null>(null)
   // Track the last `value` we saw so we can reset the override on navigation
   // (when a new page provides a fresh SSR value, any stale editor override is dropped).
@@ -25,6 +28,21 @@ export function GlobalConfigProvider(props: {
     setLastValue(value)
     setOverride(null)
   }
+
+  // Editor-language refetch: pages other than `/global-config` fetch the
+  // globalConfig in the storefront's language server-side. When the editor
+  // shows a different language we refetch client-side once so USPs / footer /
+  // etc. match the editor selection across the whole site.
+  useEffect(() => {
+    if (skip || editorLanguage === undefined) return undefined
+    let cancelled = false
+    fetchGlobalConfig({ preview: true, language: editorLanguage }).then((story) => {
+      if (!cancelled && story?.content) setOverride(story.content)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [skip, editorLanguage])
 
   const config = override ?? value ?? null
 

--- a/examples/magento-storyblok/lib/graphql/graphqlSsrClient.ts
+++ b/examples/magento-storyblok/lib/graphql/graphqlSsrClient.ts
@@ -36,7 +36,7 @@ function client(context: GetStaticPropsContext, fetchPolicy: FetchPolicy = 'no-c
     defaultOptions: {
       preview: context as PreviewConfig,
       query: { errorPolicy: 'all', fetchPolicy },
-    } as ApolloClient.DefaultOptions,
+    },
   })
 }
 

--- a/examples/magento-storyblok/lib/storyblok.ts
+++ b/examples/magento-storyblok/lib/storyblok.ts
@@ -39,19 +39,30 @@ export async function fetchGlobalConfig(opts?: FetchStoryOpts): Promise<GlobalCo
 }
 
 /**
- * The wrapped `useStoryblokState` hook subscribes to the Storyblok Visual Editor bridge for
- * live updates and resolves `row_product` blocks client-side. Both are only useful inside the
- * Visual Editor — Storyblok loads the page in an iframe with `_storyblok` in the query string,
- * which is how we detect editor mode here. Outside the editor (regular visitors and soft navs
- * between routes) `initialStory` is already fully resolved server-side in `getStaticProps`, so
- * we pass `skip: true` to short-circuit the bridge and resolution work.
+ * Reads the Storyblok Visual Editor mode and language from the page's query string. Used by the
+ * `useStoryblokState` wrappers below to decide whether to enable bridge subscription + product
+ * resolution and to refetch in the editor-selected language. Outside the editor (regular
+ * visitors and soft navs) `initialStory` is already fully resolved by `fetchStory` in
+ * `getStaticProps` so the inner hook short-circuits via `skip: true`.
  */
+export function useEditorState() {
+  const query = useRouter().query
+  const isEditor = Boolean(query._storyblok)
+  // eslint-disable-next-line no-underscore-dangle
+  const rawLang = typeof query._storyblok_lang === 'string' ? query._storyblok_lang : undefined
+  const editorLanguage = isEditor && rawLang ? (rawLang === 'default' ? '' : rawLang) : undefined
+  return { skip: !isEditor, editorLanguage }
+}
+
 export const useStoryblokState = (
   initialStory: ISbStoryData | null,
-): ISbStoryData<StoryblokPage> | null => {
-  const isEditor = Boolean(useRouter().query._storyblok)
-  return useStoryblokStateBase<StoryblokPage>(initialStory, { skip: !isEditor })
-}
+): ISbStoryData<StoryblokPage> | null =>
+  useStoryblokStateBase<StoryblokPage>(initialStory, useEditorState())
+
+export const useGlobalConfigState = (
+  initialStory: ISbStoryData | null,
+): ISbStoryData<StoryblokGlobalConfig> | null =>
+  useStoryblokStateBase<StoryblokGlobalConfig>(initialStory, useEditorState())
 
 export const getStoryblokApi = storyblokInit({
   accessToken: storyblok.accessToken,

--- a/examples/magento-storyblok/pages/api/storyblok-preview.ts
+++ b/examples/magento-storyblok/pages/api/storyblok-preview.ts
@@ -1,24 +1,37 @@
+import { previewSecret } from '@graphcommerce/next-config/config'
 import type { NextApiRequest, NextApiResponse } from 'next'
 
 /**
  * Storyblok calls this endpoint when the Visual Editor opens a page. It enables Next.js preview
- * mode (so `getStaticProps` receives `context.preview = true` → draft content) and redirects to the
- * requested slug.
+ * mode (so `getStaticProps` receives `context.preview = true` → draft content) and redirects to
+ * the requested slug, preserving the `_storyblok*` query params so the Bridge script activates
+ * on the destination page (it reads them from `window.location.search`).
  *
  * Configure in Storyblok: Settings → Visual Editor → Preview URLs → add
  * `https://<domain>/api/storyblok-preview?secret=<token>&slug=<slug>`
  *
- * The `_storyblok` query param is preserved so the Bridge script activates on the destination page.
+ * The secret is GraphCommerce's `previewSecret` config (or `GC_PREVIEW_SECRET` env var) — the
+ * same mechanism used elsewhere in the platform to gate preview mode.
  */
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
   const { secret, slug = '' } = req.query
 
-  if (secret !== process.env.STORYBLOK_PREVIEW_SECRET) {
+  if (!previewSecret || secret !== previewSecret) {
     return res.status(401).json({ message: 'Invalid preview secret' })
   }
 
   res.setPreviewData({})
 
+  // Drop `secret` and `slug` (this route's own inputs) and forward everything
+  // else — the Bridge script needs `_storyblok` etc. on the destination page.
+  const forwarded = new URLSearchParams()
+  for (const [key, value] of Object.entries(req.query)) {
+    if (key === 'secret' || key === 'slug') continue
+    if (typeof value === 'string') forwarded.append(key, value)
+    else if (Array.isArray(value)) value.forEach((v) => forwarded.append(key, v))
+  }
+
   const resolvedSlug = slug === 'home' ? '/' : `/${slug}`
-  return res.redirect(resolvedSlug)
+  const queryString = forwarded.toString()
+  res.redirect(queryString ? `${resolvedSlug}?${queryString}` : resolvedSlug)
 }

--- a/examples/magento-storyblok/pages/global-config.tsx
+++ b/examples/magento-storyblok/pages/global-config.tsx
@@ -5,12 +5,11 @@ import { LayoutHeader, PageMeta, revalidate } from '@graphcommerce/next-ui'
 import type { GetStaticProps } from '@graphcommerce/next-ui'
 import { storyblokEditable } from '@graphcommerce/storyblok-ui'
 import { Box, Container, Stack, Typography } from '@mui/material'
-import { useStoryblokState } from '@storyblok/react'
 import type { LayoutNavigationProps } from '../components'
 import { LayoutDocument, LayoutNavigation, Usps } from '../components'
 import { useSetGlobalConfig } from '../components/Storyblok/GlobalConfigProvider'
 import { graphqlSharedClient, graphqlSsrClient } from '../lib/graphql/graphqlSsrClient'
-import { fetchGlobalConfig, type GlobalConfigStory } from '../lib/storyblok'
+import { fetchGlobalConfig, useGlobalConfigState, type GlobalConfigStory } from '../lib/storyblok'
 
 type GlobalConfigPageProps = {
   globalConfigStory: GlobalConfigStory | null
@@ -19,7 +18,7 @@ type GetPageStaticProps = GetStaticProps<LayoutNavigationProps, GlobalConfigPage
 
 function GlobalConfigPage(props: GlobalConfigPageProps) {
   const { globalConfigStory } = props
-  const story = useStoryblokState(globalConfigStory)
+  const story = useGlobalConfigState(globalConfigStory)
   const globalConfig = story?.content
 
   useSetGlobalConfig(globalConfig)

--- a/packages/graphql/apolloTypeOverrides.d.ts
+++ b/packages/graphql/apolloTypeOverrides.d.ts
@@ -1,0 +1,34 @@
+/**
+ * Apollo Client 4.2+ type augmentations for the GraphCommerce setup.
+ *
+ * - `DefaultOptions.Input.preview` declares the `preview` extension GraphCommerce stuffs into
+ *   defaultOptions so it's part of the type instead of needing an `as unknown` cast at every
+ *   client-construction site.
+ * - `DeclareDefaultOptions.Query.errorPolicy: 'all'` opts the SSR clients into errorPolicy 'all'
+ *   so partial GraphQL responses are returned alongside errors instead of throwing on every
+ *   field-level error during SSG.
+ * - `signatureStyle: 'classic'` keeps the pre-4.2 query result typing (`T` instead of
+ *   `DeepPartial<T> | undefined`) so the codebase doesn't need an app-wide migration to handle
+ *   the now-correctly-modelled partial data. This is a deliberate trade-off — TS doesn't model
+ *   the runtime reality of errorPolicy 'all', but it keeps consumer code ergonomic.
+ */
+import '@apollo/client'
+
+declare module '@apollo/client' {
+  namespace ApolloClient {
+    namespace DefaultOptions {
+      interface Input {
+        preview: unknown
+      }
+    }
+    namespace DeclareDefaultOptions {
+      interface Query {
+        errorPolicy?: 'all'
+      }
+    }
+  }
+
+  interface TypeOverrides {
+    signatureStyle: 'classic'
+  }
+}

--- a/packages/graphql/components/GraphQLProvider/GraphQLProvider.tsx
+++ b/packages/graphql/components/GraphQLProvider/GraphQLProvider.tsx
@@ -76,7 +76,7 @@ export function GraphQLProvider(props: GraphQLProviderProps) {
         preview: {
           preview: router.isPreview,
         } as PreviewConfig,
-      } as ApolloClient.DefaultOptions,
+      },
       localState: new LocalState({}),
     })
   })

--- a/packages/graphql/index.ts
+++ b/packages/graphql/index.ts
@@ -1,3 +1,5 @@
+/// <reference path="./apolloTypeOverrides.d.ts" />
+
 export * from './apollo'
 export * from './components/GraphQLProvider'
 export { default as fragments } from './generated/fragments.json'

--- a/packages/storyblok-ui/Config.graphqls
+++ b/packages/storyblok-ui/Config.graphqls
@@ -30,3 +30,16 @@ extend input GraphCommerceConfig {
   """
   storyblok: StoryblokConfig!
 }
+
+extend input GraphCommerceStorefrontConfig {
+  """
+  Storyblok language code to request for this storefront. Maps the storefront's
+  GraphCommerce locale to a Storyblok language version. When unset, the storefront's
+  GraphCommerce locale prefix is used as the language code, unless it matches the
+  default locale (in which case no `language` param is sent and Storyblok serves
+  its space-default language). Set this when the GraphCommerce default locale
+  differs from the Storyblok default language (e.g. GraphCommerce default `nl_NL`
+  while the Storyblok space default stays English).
+  """
+  storyblokLocale: String
+}

--- a/packages/storyblok-ui/lib/fetch.ts
+++ b/packages/storyblok-ui/lib/fetch.ts
@@ -1,4 +1,5 @@
 import type { ApolloClient } from '@graphcommerce/graphql'
+import { storefrontConfig } from '@graphcommerce/next-ui'
 import {
   getStoryblokApi,
   type ISbStoriesParams,
@@ -18,6 +19,14 @@ export type FetchStoryOpts = {
    * into full story objects in the response (e.g. `row_button_link_list.links`).
    */
   resolveRelations?: string | string[]
+  /**
+   * Direct Storyblok language override. When set, takes precedence over the
+   * storefront-config based `storyblokLocale` and the locale-prefix fallback.
+   * Empty string means "no `language` param" — Storyblok serves its space
+   * default. Used by `useStoryblokState` to refetch in the editor's selected
+   * language.
+   */
+  language?: string
 }
 export type FetchStoriesParams = ISbStoriesParams & FetchStoryOpts
 
@@ -36,6 +45,18 @@ export const sbParams = (opts: FetchStoryOpts = {}) => {
   const lang = langPrefix(opts.locale)
   const defaultLang = langPrefix(opts.defaultLocale)
   const isDefault = !lang || lang === defaultLang
+  // Per-storefront override — lets projects map a GraphCommerce locale to a
+  // Storyblok language explicitly. Needed when the GC default locale differs
+  // from the Storyblok space's default language (e.g. GC default `nl_NL` while
+  // Storyblok stays English-default). When unset, fall back to the legacy
+  // locale-prefix heuristic.
+  const explicitLanguage = storefrontConfig(opts.locale)?.storyblokLocale
+  // Direct override has highest priority. Empty string = no `language` param
+  // (Storyblok serves its default language).
+  const language =
+    opts.language !== undefined
+      ? opts.language || undefined
+      : (explicitLanguage ?? (!isDefault ? lang : undefined))
 
   const resolveRelations = Array.isArray(opts.resolveRelations)
     ? opts.resolveRelations.join(',')
@@ -49,7 +70,7 @@ export const sbParams = (opts: FetchStoryOpts = {}) => {
     resolve_links: 'story' as const,
     ...(resolveRelations && { resolve_relations: resolveRelations }),
     ...(isDev && { cv: Date.now() }),
-    ...(!isDefault && { language: lang }),
+    ...(language && { language }),
   }
 }
 

--- a/packages/storyblok-ui/lib/useStoryblokState.ts
+++ b/packages/storyblok-ui/lib/useStoryblokState.ts
@@ -5,6 +5,7 @@ import {
   type SbBlokData,
 } from '@storyblok/react'
 import { useEffect, useRef, useState } from 'react'
+import { fetchStory } from './fetch'
 import { resolveStoryblokProducts } from './resolveProducts'
 
 export type UseStoryblokStateOptions = {
@@ -14,6 +15,14 @@ export type UseStoryblokStateOptions = {
    * fully resolved by `fetchStory` in `getStaticProps`.
    */
   skip?: boolean
+  /**
+   * Storyblok language code the Visual Editor is currently showing. When
+   * different from `initialStory`'s language, the hook refetches the story
+   * in this language on mount so the editor preview matches the editor's
+   * sidebar selection regardless of which GraphCommerce storefront the page
+   * renders in. Empty string means "Storyblok-default language".
+   */
+  editorLanguage?: string
 }
 
 /**
@@ -22,17 +31,51 @@ export type UseStoryblokStateOptions = {
  * `magento_category_id` fields are changed.
  *
  * The generic `T` lets the caller narrow the returned `content` to an auto-generated Storyblok
- * content type. The runtime check guards against feeding in a story whose content isn't a `page`.
+ * content type.
  */
 export function useStoryblokState<T = SbBlokData>(
   initialStory: ISbStoryData | null,
   options: UseStoryblokStateOptions = {},
 ): ISbStoryData<T> | null {
-  const { skip = false } = options
+  const { skip = false, editorLanguage } = options
   const story = useStoryblokStateBase(initialStory, { resolveLinks: 'story' })
   const client = useApolloClient()
   const [resolvedStory, setResolvedStory] = useState(story)
   const prevStoryRef = useRef(story)
+
+  // Editor language refetch: Storyblok's bridge doesn't proactively push
+  // content on language switches (only on field edits), and preview cookies
+  // can't reach getStaticProps from third-party iframes. So when the editor's
+  // language differs from the initial SSR fetch we refetch client-side once.
+  useEffect(() => {
+    if (skip || editorLanguage === undefined || !initialStory?.full_slug) return
+    const target = editorLanguage || 'default'
+    const current = initialStory.lang ?? 'default'
+    if (target === current) return
+
+    // Storyblok's `full_slug` is prefixed with the language folder (e.g.
+    // `nl/home`). Strip it so the refetch targets the canonical story
+    // regardless of which language we're switching to.
+    const lang = initialStory.lang
+    const baseSlug =
+      lang && lang !== 'default' && initialStory.full_slug.startsWith(`${lang}/`)
+        ? initialStory.full_slug.slice(lang.length + 1)
+        : initialStory.full_slug
+
+    let cancelled = false
+    fetchStory(baseSlug, { preview: true, language: editorLanguage }, client).then(
+      (result) => {
+        if (cancelled) return
+        const fetched = result.data?.story
+        if (!fetched) return
+        prevStoryRef.current = fetched
+        setResolvedStory(fetched as typeof story)
+      },
+    )
+    return () => {
+      cancelled = true
+    }
+  }, [skip, editorLanguage, initialStory, client])
 
   useEffect(() => {
     if (skip) return
@@ -53,16 +96,5 @@ export function useStoryblokState<T = SbBlokData>(
   }, [skip, story, client])
 
   const finalStory = skip ? initialStory : resolvedStory
-
-  if (!finalStory) return null
-  if (finalStory.content?.component === 'page') {
-    return finalStory as ISbStoryData<T>
-  }
-
-  if (process.env.NODE_ENV === 'development') {
-    throw new Error(
-      `useStoryblokState: expected story content of type 'page' but got '${finalStory.content?.component}' for slug '${finalStory.full_slug}'. Use the upstream @storyblok/react useStoryblokState for non-page content.`,
-    )
-  }
-  return null
+  return (finalStory as ISbStoryData<T> | null) ?? null
 }


### PR DESCRIPTION
Adds a per-storefront storyblokLocale config to map GraphCommerce locales to Storyblok language codes, and refetches stories + global config client-side in the editor's selected language so previews match the editor sidebar regardless of which storefront the page renders in.