### PR TITLE
Feature/layout navigation

### DIFF
--- a/.changeset/kind-days-punch.md
+++ b/.changeset/kind-days-punch.md
@@ -1,0 +1,6 @@
+---
+'@graphcommerce/magento-cart': patch
+'@graphcommerce/next-ui': patch
+---
+
+Added disableScrollEffects prop to CartFab & NavigationFab for easier customization of the header

--- a/.changeset/true-suits-design.md
+++ b/.changeset/true-suits-design.md
@@ -1,0 +1,8 @@
+---
+'@graphcommerce/magento-open-source': minor
+'@graphcommerce/magento-storyblok': minor
+'@graphcommerce/magento-graphcms': minor
+'@graphcommerce/next-ui': minor
+---
+
+Refactored `LayoutNavigation` into composable pieces (`Header`, `HeaderContainer`, `MenuOverlay`, project-local `LayoutDefault`). `LayoutDefault` / `LayoutDefaultProps` in `@graphcommerce/next-ui` are marked `@deprecated` — the canonical version now lives locally in `components/Layout/`.

--- a/.changeset/true-suits-design.md
+++ b/.changeset/true-suits-design.md
@@ -5,4 +5,4 @@
 '@graphcommerce/next-ui': minor
 ---
 
-Refactored `LayoutNavigation` into composable pieces (`Header`, `HeaderContainer`, `MenuOverlay`, project-local `LayoutDefault`). `LayoutDefault` / `LayoutDefaultProps` in `@graphcommerce/next-ui` are marked `@deprecated` — the canonical version now lives locally in `components/Layout/`.
+Refactored `LayoutNavigation` into composable pieces (`Header`, `HeaderContainer`, `MenuOverlay`, project-local `LayoutDefault`). `LayoutDefault` / `LayoutDefaultProps` in `@graphcommerce/next-ui` are marked `@deprecated`. If you are upgrading and do not want these changes, you can just discard them. This is just a structural change for more ease of use. No visually change.

--- a/.changeset/yummy-spies-change.md
+++ b/.changeset/yummy-spies-change.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/next-ui': patch
+---
+
+Changed Footer props type to allow setting footer container props

--- a/examples/magento-graphcms/components/Layout/Header.tsx
+++ b/examples/magento-graphcms/components/Layout/Header.tsx
@@ -1,0 +1,82 @@
+import { useCartEnabled } from '@graphcommerce/magento-cart'
+import { CustomerFab } from '@graphcommerce/magento-customer'
+import { SearchFab, SearchField } from '@graphcommerce/magento-search'
+import { StoreSwitcherButton, StoreSwitcherFab } from '@graphcommerce/magento-store'
+import { WishlistFab } from '@graphcommerce/magento-wishlist'
+import {
+  DesktopNavActions,
+  DesktopNavBar,
+  DesktopNavItem,
+  iconChevronDown,
+  iconCustomerService,
+  iconHeart,
+  IconSvg,
+  MobileTopRight,
+  PlaceholderFab,
+  type UseNavigationSelection,
+} from '@graphcommerce/next-ui'
+import { t } from '@lingui/core/macro'
+import { Trans } from '@lingui/react/macro'
+import { Fab } from '@mui/material'
+import { productListRenderer } from '../ProductListItems/productListRenderer'
+import { HeaderContainer } from './HeaderContainer'
+import type { LayoutQuery } from './Layout.gql'
+import { Logo } from './Logo'
+
+export type HeaderProps = LayoutQuery & { selection: UseNavigationSelection }
+
+export function Header(props: HeaderProps) {
+  const { menu, selection } = props
+  const cartEnabled = useCartEnabled()
+
+  return (
+    <HeaderContainer>
+      <Logo />
+
+      <DesktopNavBar>
+        {menu?.items?.[0]?.children?.slice(0, 2).map((item) => (
+          <DesktopNavItem key={item?.uid} href={`/${item?.url_path}`}>
+            {item?.name}
+          </DesktopNavItem>
+        ))}
+
+        <DesktopNavItem
+          onClick={() => selection.set([menu?.items?.[0]?.uid || ''])}
+          onKeyUp={(evt) => {
+            if (evt.key === 'Enter') {
+              selection.set([menu?.items?.[0]?.uid || ''])
+            }
+          }}
+          tabIndex={0}
+        >
+          {menu?.items?.[0]?.name}
+          <IconSvg src={iconChevronDown} />
+        </DesktopNavItem>
+
+        <DesktopNavItem href='/blog'>
+          <Trans>Blog</Trans>
+        </DesktopNavItem>
+      </DesktopNavBar>
+
+      <DesktopNavActions>
+        <SearchField
+          formControl={{ sx: { width: '400px' } }}
+          searchField={{ productListRenderer }}
+        />
+        <StoreSwitcherButton />
+        <Fab href='/service' aria-label={t`Customer Service`} size='large' color='inherit'>
+          <IconSvg src={iconCustomerService} size='large' />
+        </Fab>
+        <WishlistFab icon={<IconSvg src={iconHeart} size='large' />} />
+        <CustomerFab guestHref='/account/signin' authHref='/account' />
+        {/* The placeholder exists because the CartFab is sticky but we want to reserve the space for the <CartFab /> */}
+        {cartEnabled && <PlaceholderFab />}
+      </DesktopNavActions>
+
+      <MobileTopRight>
+        <StoreSwitcherFab size='responsiveMedium' />
+        <SearchFab size='responsiveMedium' />
+      </MobileTopRight>
+    </HeaderContainer>
+  )
+}

--- a/examples/magento-graphcms/components/Layout/HeaderContainer.tsx
+++ b/examples/magento-graphcms/components/Layout/HeaderContainer.tsx
@@ -1,0 +1,40 @@
+import type { ContainerSizingProps } from '@graphcommerce/next-ui'
+import { Container, sxx } from '@graphcommerce/next-ui'
+
+export type HeaderContainerProps = ContainerSizingProps
+
+export function HeaderContainer(props: HeaderContainerProps) {
+  const { children, sx, ...containerProps } = props
+  
+  return (
+    <Container
+      sizing='shell'
+      maxWidth={false}
+      component='header'
+      {...containerProps}
+      sx={sxx(
+        (theme) => ({
+          zIndex: theme.zIndex.appBar - 1,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          height: theme.appShell.headerHeightSm,
+          pointerEvents: 'none',
+          '& > *': {
+            pointerEvents: 'all',
+          },
+          [theme.breakpoints.up('md')]: {
+            height: theme.appShell.headerHeightMd,
+            top: 0,
+            display: 'flex',
+            justifyContent: 'left',
+            width: '100%',
+          },
+        }),
+        sx,
+      )}
+    >
+      {children}
+    </Container>
+  )
+}

--- a/examples/magento-graphcms/components/Layout/LayoutDefault.tsx
+++ b/examples/magento-graphcms/components/Layout/LayoutDefault.tsx
@@ -75,38 +75,7 @@ export function LayoutDefault(props: LayoutDefaultProps) {
       <SkipLink />
       <LayoutProvider scroll={scrollYOffset}>
         {beforeHeader}
-        <Container
-          sizing='shell'
-          maxWidth={false}
-          component='header'
-          className={classes.header}
-          sx={(theme) => ({
-            zIndex: theme.zIndex.appBar - 1,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            height: theme.appShell.headerHeightSm,
-            pointerEvents: 'none',
-            '& > *': {
-              pointerEvents: 'all',
-            },
-            [theme.breakpoints.up('md')]: {
-              height: theme.appShell.headerHeightMd,
-              top: 0,
-              display: 'flex',
-              justifyContent: 'left',
-              width: '100%',
-            },
-            '&.sticky': {
-              [theme.breakpoints.down('md')]: {
-                position: 'sticky',
-                top: 0,
-              },
-            },
-          })}
-        >
-          {header}
-        </Container>
+        {header}
         {menuFab || cartFab ? (
           <Container
             sizing='shell'

--- a/examples/magento-graphcms/components/Layout/LayoutDefault.tsx
+++ b/examples/magento-graphcms/components/Layout/LayoutDefault.tsx
@@ -1,0 +1,165 @@
+import { useScrollOffset } from '@graphcommerce/framer-next-pages'
+import { dvh } from '@graphcommerce/framer-utils'
+import {
+  Container,
+  extendableComponent,
+  LayoutProvider,
+  SkipLink,
+  sxx,
+  useFabSize,
+} from '@graphcommerce/next-ui'
+import type { SxProps, Theme } from '@mui/material'
+import { Box } from '@mui/material'
+import { useScroll, useTransform } from 'framer-motion'
+
+export type LayoutDefaultProps = {
+  className?: string
+  beforeHeader?: React.ReactNode
+  header: React.ReactNode
+  footer: React.ReactNode
+  menuFab?: React.ReactNode
+  cartFab?: React.ReactNode
+  children?: React.ReactNode
+  noSticky?: boolean
+  sx?: SxProps<Theme>
+} & OwnerState
+
+type OwnerState = {
+  noSticky?: boolean
+}
+const parts = ['root', 'fabs', 'header', 'children', 'footer'] as const
+const { withState } = extendableComponent<OwnerState, 'LayoutDefault', typeof parts>(
+  'LayoutDefault',
+  parts,
+)
+
+export function LayoutDefault(props: LayoutDefaultProps) {
+  const {
+    children,
+    header,
+    beforeHeader,
+    footer,
+    menuFab,
+    cartFab,
+    noSticky,
+    className,
+    sx = [],
+  } = props
+
+  const { scrollY } = useScroll()
+  const scrollYOffset = useTransform(
+    [scrollY, useScrollOffset()],
+    ([y, offset]: number[]) => y + offset,
+  )
+
+  const classes = withState({ noSticky })
+  const fabIconSize = useFabSize('responsive')
+
+  return (
+    <Box
+      className={`${classes.root} ${className ?? ''}`}
+      sx={sxx(
+        (theme) => ({
+          minHeight: dvh(100),
+          '@supports (-webkit-touch-callout: none)': {
+            minHeight: '-webkit-fill-available',
+          },
+          display: 'grid',
+          gridTemplateRows: { xs: 'auto 1fr auto', md: 'auto auto 1fr auto' },
+          gridTemplateColumns: '100%',
+          background: theme.vars.palette.background.default,
+        }),
+        sx,
+      )}
+    >
+      <SkipLink />
+      <LayoutProvider scroll={scrollYOffset}>
+        {beforeHeader}
+        <Container
+          sizing='shell'
+          maxWidth={false}
+          component='header'
+          className={classes.header}
+          sx={(theme) => ({
+            zIndex: theme.zIndex.appBar - 1,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            height: theme.appShell.headerHeightSm,
+            pointerEvents: 'none',
+            '& > *': {
+              pointerEvents: 'all',
+            },
+            [theme.breakpoints.up('md')]: {
+              height: theme.appShell.headerHeightMd,
+              top: 0,
+              display: 'flex',
+              justifyContent: 'left',
+              width: '100%',
+            },
+            '&.sticky': {
+              [theme.breakpoints.down('md')]: {
+                position: 'sticky',
+                top: 0,
+              },
+            },
+          })}
+        >
+          {header}
+        </Container>
+        {menuFab || cartFab ? (
+          <Container
+            sizing='shell'
+            maxWidth={false}
+            className={classes.fabs}
+            sx={(theme) => ({
+              display: 'flex',
+              justifyContent: 'space-between',
+              width: '100%',
+              height: 0,
+              zIndex: 'speedDial',
+              [theme.breakpoints.up('sm')]: {
+                position: 'sticky',
+                marginTop: `calc(${theme.appShell.headerHeightMd} * -1 - calc(${fabIconSize} / 2))`,
+                top: `calc(${theme.appShell.headerHeightMd} / 2 - (${fabIconSize} / 2))`,
+              },
+              [theme.breakpoints.down('md')]: {
+                position: 'fixed',
+                top: 'unset',
+                bottom: `calc(20px + ${fabIconSize})`,
+                padding: '0 20px',
+                '@media (max-height: 530px) and (orientation: portrait)': {
+                  display: 'none',
+                },
+              },
+            })}
+          >
+            {menuFab}
+            {cartFab && (
+              <Box
+                sx={(theme) => ({
+                  display: 'flex',
+                  flexDirection: 'row-reverse',
+                  gap: theme.spacings.sm,
+                  [theme.breakpoints.up('md')]: {
+                    flexDirection: 'column',
+                    alignItems: 'flex-end',
+                  },
+                })}
+              >
+                {cartFab}
+              </Box>
+            )}
+          </Container>
+        ) : (
+          <div />
+        )}
+        <div className={classes.children}>
+          <div id='skip-nav' tabIndex={-1} />
+          {children}
+        </div>
+        <div className={classes.footer}>{footer}</div>
+      </LayoutProvider>
+    </Box>
+  )
+}

--- a/examples/magento-graphcms/components/Layout/LayoutMinimal.tsx
+++ b/examples/magento-graphcms/components/Layout/LayoutMinimal.tsx
@@ -1,6 +1,7 @@
-import { LayoutDefault, LayoutDefaultProps } from '@graphcommerce/next-ui'
 import { Footer } from './Footer'
+import { HeaderContainer } from './HeaderContainer'
 import { LayoutQuery } from './Layout.gql'
+import { LayoutDefault, type LayoutDefaultProps } from './LayoutDefault'
 import { Logo } from './Logo'
 
 export type LayoutMinimalProps = LayoutQuery &
@@ -12,7 +13,11 @@ export function LayoutMinimal(props: LayoutMinimalProps) {
   return (
     <LayoutDefault
       {...uiProps}
-      header={<Logo />}
+      header={
+        <HeaderContainer>
+          <Logo />
+        </HeaderContainer>
+      }
       footer={<Footer footer={footer} />}
       sx={(theme) => ({ background: theme.vars.palette.background.paper })}
     >

--- a/examples/magento-graphcms/components/Layout/LayoutNavigation.tsx
+++ b/examples/magento-graphcms/components/Layout/LayoutNavigation.tsx
@@ -1,40 +1,11 @@
-import { CartFab, useCartEnabled } from '@graphcommerce/magento-cart'
-import { magentoMenuToNavigation } from '@graphcommerce/magento-category'
-import { CustomerFab, CustomerMenuFabItem } from '@graphcommerce/magento-customer'
-import { SearchFab, SearchField } from '@graphcommerce/magento-search'
-import { WishlistFab, WishlistMenuFabItem } from '@graphcommerce/magento-wishlist'
-import {
-  DesktopNavActions,
-  DesktopNavBar,
-  iconCustomerService,
-  iconHeart,
-  NavigationFab,
-  MenuFabSecondaryItem,
-  PlaceholderFab,
-  IconSvg,
-  DesktopNavItem,
-  DarkLightModeMenuSecondaryItem,
-  iconChevronDown,
-  NavigationProvider,
-  NavigationOverlay,
-  useNavigationSelection,
-  useMemoDeep,
-  MobileTopRight,
-} from '@graphcommerce/next-ui'
-import { t } from '@lingui/core/macro'
-import { Trans } from '@lingui/react/macro'
-import { Divider, Fab } from '@mui/material'
+import { CartFab } from '@graphcommerce/magento-cart'
+import { NavigationFab, useNavigationSelection } from '@graphcommerce/next-ui'
 import { useRouter } from 'next/router'
 import { Footer } from './Footer'
-import { LayoutQuery } from './Layout.gql'
-import { Logo } from './Logo'
-import { productListRenderer } from '../ProductListItems/productListRenderer'
-import {
-  StoreSwitcherButton,
-  StoreSwitcherFab,
-  StoreSwitcherMenuFabSecondaryItem,
-} from '@graphcommerce/magento-store'
+import { Header } from './Header'
+import type { LayoutQuery } from './Layout.gql'
 import { LayoutDefault, type LayoutDefaultProps } from './LayoutDefault'
+import { MenuOverlay } from './MenuOverlay'
 
 export type LayoutNavigationProps = LayoutQuery &
   Omit<LayoutDefaultProps, 'footer' | 'header' | 'cartFab' | 'menuFab'>
@@ -44,124 +15,15 @@ export function LayoutNavigation(props: LayoutNavigationProps) {
 
   const selection = useNavigationSelection()
   const router = useRouter()
-  const cartEnabled = useCartEnabled()
 
   return (
     <>
-      <NavigationProvider
-        selection={selection}
-        items={useMemoDeep(
-          () => [
-            { id: 'home', name: <Trans>Home</Trans>, href: '/' },
-            {
-              id: 'manual-item-one',
-              href: `/${menu?.items?.[0]?.children?.[0]?.url_path}`,
-              name: menu?.items?.[0]?.children?.[0]?.name ?? '',
-            },
-            {
-              id: 'manual-item-two',
-              href: `/${menu?.items?.[0]?.children?.[1]?.url_path}`,
-              name: menu?.items?.[0]?.children?.[1]?.name ?? '',
-            },
-            ...magentoMenuToNavigation(menu, true),
-            { id: 'blog', name: 'Blog', href: '/blog' },
-            <Divider key='divider' sx={(theme) => ({ my: theme.spacings.xs })} />,
-            <CustomerMenuFabItem
-              onClick={() => selection.set(false)}
-              key='account'
-              guestHref='/account/signin'
-              authHref='/account'
-            >
-              <Trans>Account</Trans>
-            </CustomerMenuFabItem>,
-            <MenuFabSecondaryItem
-              key='service'
-              icon={<IconSvg src={iconCustomerService} size='medium' />}
-              href='/service'
-            >
-              <Trans>Customer Service</Trans>
-            </MenuFabSecondaryItem>,
-            <WishlistMenuFabItem
-              onClick={() => selection.set(false)}
-              key='wishlist'
-              icon={<IconSvg src={iconHeart} size='medium' />}
-            >
-              <Trans>Wishlist</Trans>
-            </WishlistMenuFabItem>,
-            <DarkLightModeMenuSecondaryItem key='darkmode' />,
-            <StoreSwitcherMenuFabSecondaryItem key='store-switcher' />,
-          ],
-          [menu, selection],
-        )}
-      >
-        <NavigationOverlay
-          stretchColumns={false}
-          variantSm='left'
-          sizeSm='full'
-          justifySm='start'
-          itemWidthSm='70vw'
-          variantMd='left'
-          sizeMd='full'
-          justifyMd='start'
-          itemWidthMd='230px'
-          mouseEvent='hover'
-          itemPadding='md'
-        />
-      </NavigationProvider>
+      <MenuOverlay menu={menu} selection={selection} />
 
       <LayoutDefault
         {...uiProps}
         noSticky={router.asPath.split('?')[0] === '/'}
-        header={
-          <>
-            <Logo />
-
-            <DesktopNavBar>
-              {menu?.items?.[0]?.children?.slice(0, 2).map((item) => (
-                <DesktopNavItem key={item?.uid} href={`/${item?.url_path}`}>
-                  {item?.name}
-                </DesktopNavItem>
-              ))}
-
-              <DesktopNavItem
-                onClick={() => selection.set([menu?.items?.[0]?.uid || ''])}
-                onKeyUp={(evt) => {
-                  if (evt.key === 'Enter') {
-                    selection.set([menu?.items?.[0]?.uid || ''])
-                  }
-                }}
-                tabIndex={0}
-              >
-                {menu?.items?.[0]?.name}
-                <IconSvg src={iconChevronDown} />
-              </DesktopNavItem>
-
-              <DesktopNavItem href='/blog'>
-                <Trans>Blog</Trans>
-              </DesktopNavItem>
-            </DesktopNavBar>
-
-            <DesktopNavActions>
-              <SearchField
-                formControl={{ sx: { width: '400px' } }}
-                searchField={{ productListRenderer }}
-              />
-              <StoreSwitcherButton />
-              <Fab href='/service' aria-label={t`Customer Service`} size='large' color='inherit'>
-                <IconSvg src={iconCustomerService} size='large' />
-              </Fab>
-              <WishlistFab icon={<IconSvg src={iconHeart} size='large' />} />
-              <CustomerFab guestHref='/account/signin' authHref='/account' />
-              {/* The placeholder exists because the CartFab is sticky but we want to reserve the space for the <CartFab /> */}
-              {cartEnabled && <PlaceholderFab />}
-            </DesktopNavActions>
-
-            <MobileTopRight>
-              <StoreSwitcherFab size='responsiveMedium' />
-              <SearchFab size='responsiveMedium' />
-            </MobileTopRight>
-          </>
-        }
+        header={<Header menu={menu} selection={selection} />}
         footer={<Footer footer={footer} />}
         cartFab={<CartFab />}
         menuFab={<NavigationFab onClick={() => selection.set([])} />}

--- a/examples/magento-graphcms/components/Layout/LayoutNavigation.tsx
+++ b/examples/magento-graphcms/components/Layout/LayoutNavigation.tsx
@@ -6,8 +6,6 @@ import { WishlistFab, WishlistMenuFabItem } from '@graphcommerce/magento-wishlis
 import {
   DesktopNavActions,
   DesktopNavBar,
-  LayoutDefault,
-  LayoutDefaultProps,
   iconCustomerService,
   iconHeart,
   NavigationFab,
@@ -36,6 +34,7 @@ import {
   StoreSwitcherFab,
   StoreSwitcherMenuFabSecondaryItem,
 } from '@graphcommerce/magento-store'
+import { LayoutDefault, type LayoutDefaultProps } from './LayoutDefault'
 
 export type LayoutNavigationProps = LayoutQuery &
   Omit<LayoutDefaultProps, 'footer' | 'header' | 'cartFab' | 'menuFab'>

--- a/examples/magento-graphcms/components/Layout/MenuOverlay.tsx
+++ b/examples/magento-graphcms/components/Layout/MenuOverlay.tsx
@@ -1,0 +1,87 @@
+import { magentoMenuToNavigation } from '@graphcommerce/magento-category'
+import { CustomerMenuFabItem } from '@graphcommerce/magento-customer'
+import { StoreSwitcherMenuFabSecondaryItem } from '@graphcommerce/magento-store'
+import { WishlistMenuFabItem } from '@graphcommerce/magento-wishlist'
+import {
+  DarkLightModeMenuSecondaryItem,
+  iconCustomerService,
+  iconHeart,
+  IconSvg,
+  MenuFabSecondaryItem,
+  NavigationOverlay,
+  NavigationProvider,
+  useMemoDeep,
+  type UseNavigationSelection,
+} from '@graphcommerce/next-ui'
+import { Trans } from '@lingui/react/macro'
+import { Divider } from '@mui/material'
+import type { LayoutQuery } from './Layout.gql'
+
+export type MenuOverlayProps = LayoutQuery & { selection: UseNavigationSelection }
+
+export function MenuOverlay(props: MenuOverlayProps) {
+  const { menu, selection } = props
+
+  return (
+    <NavigationProvider
+      selection={selection}
+      items={useMemoDeep(
+        () => [
+          { id: 'home', name: <Trans>Home</Trans>, href: '/' },
+          {
+            id: 'manual-item-one',
+            href: `/${menu?.items?.[0]?.children?.[0]?.url_path}`,
+            name: menu?.items?.[0]?.children?.[0]?.name ?? '',
+          },
+          {
+            id: 'manual-item-two',
+            href: `/${menu?.items?.[0]?.children?.[1]?.url_path}`,
+            name: menu?.items?.[0]?.children?.[1]?.name ?? '',
+          },
+          ...magentoMenuToNavigation(menu, true),
+          { id: 'blog', name: 'Blog', href: '/blog' },
+          <Divider key='divider' sx={(theme) => ({ my: theme.spacings.xs })} />,
+          <CustomerMenuFabItem
+            onClick={() => selection.set(false)}
+            key='account'
+            guestHref='/account/signin'
+            authHref='/account'
+          >
+            <Trans>Account</Trans>
+          </CustomerMenuFabItem>,
+          <MenuFabSecondaryItem
+            key='service'
+            icon={<IconSvg src={iconCustomerService} size='medium' />}
+            href='/service'
+          >
+            <Trans>Customer Service</Trans>
+          </MenuFabSecondaryItem>,
+          <WishlistMenuFabItem
+            onClick={() => selection.set(false)}
+            key='wishlist'
+            icon={<IconSvg src={iconHeart} size='medium' />}
+          >
+            <Trans>Wishlist</Trans>
+          </WishlistMenuFabItem>,
+          <DarkLightModeMenuSecondaryItem key='darkmode' />,
+          <StoreSwitcherMenuFabSecondaryItem key='store-switcher' />,
+        ],
+        [menu, selection],
+      )}
+    >
+      <NavigationOverlay
+        stretchColumns={false}
+        variantSm='left'
+        sizeSm='full'
+        justifySm='start'
+        itemWidthSm='70vw'
+        variantMd='left'
+        sizeMd='full'
+        justifyMd='start'
+        itemWidthMd='230px'
+        mouseEvent='hover'
+        itemPadding='md'
+      />
+    </NavigationProvider>
+  )
+}

--- a/examples/magento-open-source/components/Layout/Header.tsx
+++ b/examples/magento-open-source/components/Layout/Header.tsx
@@ -1,0 +1,84 @@
+import { useCartEnabled } from '@graphcommerce/magento-cart'
+import { CustomerFab } from '@graphcommerce/magento-customer'
+import { SearchFab, SearchField } from '@graphcommerce/magento-search'
+import { StoreSwitcherButton, StoreSwitcherFab } from '@graphcommerce/magento-store'
+import { WishlistFab } from '@graphcommerce/magento-wishlist'
+import {
+  DesktopNavActions,
+  DesktopNavBar,
+  DesktopNavItem,
+  iconChevronDown,
+  iconCustomerService,
+  iconHeart,
+  IconSvg,
+  MobileTopRight,
+  PlaceholderFab,
+  type UseNavigationSelection,
+} from '@graphcommerce/next-ui'
+import { t } from '@lingui/core/macro'
+import { Fab } from '@mui/material'
+import { productListRenderer } from '../ProductListItems/productListRenderer'
+import { HeaderContainer } from './HeaderContainer'
+import type { LayoutQuery } from './Layout.gql'
+import { Logo } from './Logo'
+
+export type HeaderProps = LayoutQuery & { selection: UseNavigationSelection }
+
+export function Header(props: HeaderProps) {
+  const { menu, selection } = props
+  const cartEnabled = useCartEnabled()
+
+  return (
+    <HeaderContainer>
+      <Logo />
+
+      <DesktopNavBar>
+        {menu?.items?.[0]?.children?.slice(0, 2).map((item) => (
+          <DesktopNavItem key={item?.uid} href={`/${item?.url_path}`}>
+            {item?.name}
+          </DesktopNavItem>
+        ))}
+
+        <DesktopNavItem
+          onClick={() => selection.set([menu?.items?.[0]?.uid || ''])}
+          onKeyUp={(evt) => {
+            if (evt.key === 'Enter') {
+              selection.set([menu?.items?.[0]?.uid || ''])
+            }
+          }}
+          tabIndex={0}
+        >
+          {menu?.items?.[0]?.name}
+          <IconSvg src={iconChevronDown} />
+        </DesktopNavItem>
+      </DesktopNavBar>
+
+      <DesktopNavActions>
+        <StoreSwitcherButton />
+        <SearchField
+          formControl={{ sx: { width: '400px' } }}
+          searchField={{ productListRenderer }}
+        />
+        <Fab href='/service' aria-label={t`Customer Service`} size='large' color='inherit'>
+          <IconSvg src={iconCustomerService} size='large' />
+        </Fab>
+        <WishlistFab
+          icon={<IconSvg src={iconHeart} size='large' />}
+          BadgeProps={{ color: 'secondary' }}
+        />
+        <CustomerFab
+          guestHref='/account/signin'
+          authHref='/account'
+          BadgeProps={{ color: 'secondary' }}
+        />
+        {/* The placeholder exists because the CartFab is sticky but we want to reserve the space for the <CartFab /> */}
+        {cartEnabled && <PlaceholderFab />}
+      </DesktopNavActions>
+
+      <MobileTopRight>
+        <StoreSwitcherFab size='responsiveMedium' />
+        <SearchFab size='responsiveMedium' />
+      </MobileTopRight>
+    </HeaderContainer>
+  )
+}

--- a/examples/magento-open-source/components/Layout/HeaderContainer.tsx
+++ b/examples/magento-open-source/components/Layout/HeaderContainer.tsx
@@ -1,0 +1,45 @@
+import type { ContainerSizingProps } from '@graphcommerce/next-ui'
+import { Container, sxx } from '@graphcommerce/next-ui'
+
+export type HeaderContainerProps = ContainerSizingProps
+
+export function HeaderContainer(props: HeaderContainerProps) {
+  const { children, sx, ...containerProps } = props
+  return (
+    <Container
+      sizing='shell'
+      maxWidth={false}
+      component='header'
+      {...containerProps}
+      sx={sxx(
+        (theme) => ({
+          zIndex: theme.zIndex.appBar - 1,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          height: theme.appShell.headerHeightSm,
+          pointerEvents: 'none',
+          '& > *': {
+            pointerEvents: 'all',
+          },
+          [theme.breakpoints.up('md')]: {
+            height: theme.appShell.headerHeightMd,
+            top: 0,
+            display: 'flex',
+            justifyContent: 'left',
+            width: '100%',
+          },
+          '&.sticky': {
+            [theme.breakpoints.down('md')]: {
+              position: 'sticky',
+              top: 0,
+            },
+          },
+        }),
+        sx,
+      )}
+    >
+      {children}
+    </Container>
+  )
+}

--- a/examples/magento-open-source/components/Layout/LayoutDefault.tsx
+++ b/examples/magento-open-source/components/Layout/LayoutDefault.tsx
@@ -75,38 +75,7 @@ export function LayoutDefault(props: LayoutDefaultProps) {
       <SkipLink />
       <LayoutProvider scroll={scrollYOffset}>
         {beforeHeader}
-        <Container
-          sizing='shell'
-          maxWidth={false}
-          component='header'
-          className={classes.header}
-          sx={(theme) => ({
-            zIndex: theme.zIndex.appBar - 1,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            height: theme.appShell.headerHeightSm,
-            pointerEvents: 'none',
-            '& > *': {
-              pointerEvents: 'all',
-            },
-            [theme.breakpoints.up('md')]: {
-              height: theme.appShell.headerHeightMd,
-              top: 0,
-              display: 'flex',
-              justifyContent: 'left',
-              width: '100%',
-            },
-            '&.sticky': {
-              [theme.breakpoints.down('md')]: {
-                position: 'sticky',
-                top: 0,
-              },
-            },
-          })}
-        >
-          {header}
-        </Container>
+        {header}
         {menuFab || cartFab ? (
           <Container
             sizing='shell'

--- a/examples/magento-open-source/components/Layout/LayoutDefault.tsx
+++ b/examples/magento-open-source/components/Layout/LayoutDefault.tsx
@@ -1,0 +1,165 @@
+import { useScrollOffset } from '@graphcommerce/framer-next-pages'
+import { dvh } from '@graphcommerce/framer-utils'
+import {
+  Container,
+  extendableComponent,
+  LayoutProvider,
+  SkipLink,
+  sxx,
+  useFabSize,
+} from '@graphcommerce/next-ui'
+import type { SxProps, Theme } from '@mui/material'
+import { Box } from '@mui/material'
+import { useScroll, useTransform } from 'framer-motion'
+
+export type LayoutDefaultProps = {
+  className?: string
+  beforeHeader?: React.ReactNode
+  header: React.ReactNode
+  footer: React.ReactNode
+  menuFab?: React.ReactNode
+  cartFab?: React.ReactNode
+  children?: React.ReactNode
+  noSticky?: boolean
+  sx?: SxProps<Theme>
+} & OwnerState
+
+type OwnerState = {
+  noSticky?: boolean
+}
+const parts = ['root', 'fabs', 'header', 'children', 'footer'] as const
+const { withState } = extendableComponent<OwnerState, 'LayoutDefault', typeof parts>(
+  'LayoutDefault',
+  parts,
+)
+
+export function LayoutDefault(props: LayoutDefaultProps) {
+  const {
+    children,
+    header,
+    beforeHeader,
+    footer,
+    menuFab,
+    cartFab,
+    noSticky,
+    className,
+    sx = [],
+  } = props
+
+  const { scrollY } = useScroll()
+  const scrollYOffset = useTransform(
+    [scrollY, useScrollOffset()],
+    ([y, offset]: number[]) => y + offset,
+  )
+
+  const classes = withState({ noSticky })
+  const fabIconSize = useFabSize('responsive')
+
+  return (
+    <Box
+      className={`${classes.root} ${className ?? ''}`}
+      sx={sxx(
+        (theme) => ({
+          minHeight: dvh(100),
+          '@supports (-webkit-touch-callout: none)': {
+            minHeight: '-webkit-fill-available',
+          },
+          display: 'grid',
+          gridTemplateRows: { xs: 'auto 1fr auto', md: 'auto auto 1fr auto' },
+          gridTemplateColumns: '100%',
+          background: theme.vars.palette.background.default,
+        }),
+        sx,
+      )}
+    >
+      <SkipLink />
+      <LayoutProvider scroll={scrollYOffset}>
+        {beforeHeader}
+        <Container
+          sizing='shell'
+          maxWidth={false}
+          component='header'
+          className={classes.header}
+          sx={(theme) => ({
+            zIndex: theme.zIndex.appBar - 1,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            height: theme.appShell.headerHeightSm,
+            pointerEvents: 'none',
+            '& > *': {
+              pointerEvents: 'all',
+            },
+            [theme.breakpoints.up('md')]: {
+              height: theme.appShell.headerHeightMd,
+              top: 0,
+              display: 'flex',
+              justifyContent: 'left',
+              width: '100%',
+            },
+            '&.sticky': {
+              [theme.breakpoints.down('md')]: {
+                position: 'sticky',
+                top: 0,
+              },
+            },
+          })}
+        >
+          {header}
+        </Container>
+        {menuFab || cartFab ? (
+          <Container
+            sizing='shell'
+            maxWidth={false}
+            className={classes.fabs}
+            sx={(theme) => ({
+              display: 'flex',
+              justifyContent: 'space-between',
+              width: '100%',
+              height: 0,
+              zIndex: 'speedDial',
+              [theme.breakpoints.up('sm')]: {
+                position: 'sticky',
+                marginTop: `calc(${theme.appShell.headerHeightMd} * -1 - calc(${fabIconSize} / 2))`,
+                top: `calc(${theme.appShell.headerHeightMd} / 2 - (${fabIconSize} / 2))`,
+              },
+              [theme.breakpoints.down('md')]: {
+                position: 'fixed',
+                top: 'unset',
+                bottom: `calc(20px + ${fabIconSize})`,
+                padding: '0 20px',
+                '@media (max-height: 530px) and (orientation: portrait)': {
+                  display: 'none',
+                },
+              },
+            })}
+          >
+            {menuFab}
+            {cartFab && (
+              <Box
+                sx={(theme) => ({
+                  display: 'flex',
+                  flexDirection: 'row-reverse',
+                  gap: theme.spacings.sm,
+                  [theme.breakpoints.up('md')]: {
+                    flexDirection: 'column',
+                    alignItems: 'flex-end',
+                  },
+                })}
+              >
+                {cartFab}
+              </Box>
+            )}
+          </Container>
+        ) : (
+          <div />
+        )}
+        <div className={classes.children}>
+          <div id='skip-nav' tabIndex={-1} />
+          {children}
+        </div>
+        <div className={classes.footer}>{footer}</div>
+      </LayoutProvider>
+    </Box>
+  )
+}

--- a/examples/magento-open-source/components/Layout/LayoutMinimal.tsx
+++ b/examples/magento-open-source/components/Layout/LayoutMinimal.tsx
@@ -1,9 +1,9 @@
 import { CmsBlock } from '@graphcommerce/magento-cms'
-import type { LayoutDefaultProps } from '@graphcommerce/next-ui'
-import { LayoutDefault } from '@graphcommerce/next-ui'
 import { productListRenderer } from '../ProductListItems'
 import { Footer } from './Footer'
+import { HeaderContainer } from './HeaderContainer'
 import type { LayoutQuery } from './Layout.gql'
+import { LayoutDefault, type LayoutDefaultProps } from './LayoutDefault'
 import { Logo } from './Logo'
 
 export type LayoutMinimalProps = LayoutQuery &
@@ -17,7 +17,11 @@ export function LayoutMinimal(props: LayoutMinimalProps) {
   return (
     <LayoutDefault
       {...uiProps}
-      header={<Logo />}
+      header={
+        <HeaderContainer>
+          <Logo />
+        </HeaderContainer>
+      }
       footer={
         <Footer
           socialLinks={

--- a/examples/magento-open-source/components/Layout/LayoutNavigation.tsx
+++ b/examples/magento-open-source/components/Layout/LayoutNavigation.tsx
@@ -1,41 +1,13 @@
-import { CartFab, useCartEnabled } from '@graphcommerce/magento-cart'
-import { magentoMenuToNavigation } from '@graphcommerce/magento-category'
+import { CartFab } from '@graphcommerce/magento-cart'
 import { CmsBlock } from '@graphcommerce/magento-cms'
-import { CustomerFab, CustomerMenuFabItem } from '@graphcommerce/magento-customer'
-import { SearchFab, SearchField } from '@graphcommerce/magento-search'
-import {
-  StoreSwitcherButton,
-  StoreSwitcherFab,
-  StoreSwitcherMenuFabSecondaryItem,
-} from '@graphcommerce/magento-store'
-import { WishlistFab, WishlistMenuFabItem } from '@graphcommerce/magento-wishlist'
-import {
-  DarkLightModeMenuSecondaryItem,
-  DesktopNavActions,
-  DesktopNavBar,
-  DesktopNavItem,
-  iconChevronDown,
-  iconCustomerService,
-  iconHeart,
-  IconSvg,
-  MenuFabSecondaryItem,
-  MobileTopRight,
-  NavigationFab,
-  NavigationOverlay,
-  NavigationProvider,
-  PlaceholderFab,
-  useMemoDeep,
-  useNavigationSelection,
-} from '@graphcommerce/next-ui'
-import { t } from '@lingui/core/macro'
-import { Trans } from '@lingui/react/macro'
-import { Divider, Fab } from '@mui/material'
+import { NavigationFab, useNavigationSelection } from '@graphcommerce/next-ui'
 import { useRouter } from 'next/router'
 import { productListRenderer } from '../ProductListItems/productListRenderer'
 import { Footer } from './Footer'
+import { Header } from './Header'
 import type { LayoutQuery } from './Layout.gql'
 import { LayoutDefault, type LayoutDefaultProps } from './LayoutDefault'
-import { Logo } from './Logo'
+import { MenuOverlay } from './MenuOverlay'
 
 export type LayoutNavigationProps = LayoutQuery &
   Omit<LayoutDefaultProps, 'footer' | 'header' | 'cartFab' | 'menuFab'>
@@ -46,126 +18,16 @@ export function LayoutNavigation(props: LayoutNavigationProps) {
   const selection = useNavigationSelection()
   const router = useRouter()
 
-  const cartEnabled = useCartEnabled()
-
   const footerBlock = cmsBlocks?.items?.find((item) => item?.identifier === 'footer_links_block')
 
   return (
     <>
-      <NavigationProvider
-        selection={selection}
-        items={useMemoDeep(
-          () => [
-            { id: 'home', name: <Trans>Home</Trans>, href: '/' },
-            {
-              id: 'manual-item-one',
-              href: `/${menu?.items?.[0]?.children?.[0]?.url_path}`,
-              name: menu?.items?.[0]?.children?.[0]?.name ?? '',
-            },
-            {
-              id: 'manual-item-two',
-              href: `/${menu?.items?.[0]?.children?.[1]?.url_path}`,
-              name: menu?.items?.[0]?.children?.[1]?.name ?? '',
-            },
-            ...magentoMenuToNavigation(menu, true),
-            <Divider key='divider' sx={(theme) => ({ my: theme.spacings.xs })} />,
-            <CustomerMenuFabItem
-              onClick={() => selection.set(false)}
-              key='account'
-              guestHref='/account/signin'
-              authHref='/account'
-            >
-              <Trans>Account</Trans>
-            </CustomerMenuFabItem>,
-            <MenuFabSecondaryItem
-              key='service'
-              icon={<IconSvg src={iconCustomerService} size='medium' />}
-              href='/service'
-            >
-              <Trans>Customer Service</Trans>
-            </MenuFabSecondaryItem>,
-            <WishlistMenuFabItem
-              onClick={() => selection.set(false)}
-              key='wishlist'
-              icon={<IconSvg src={iconHeart} size='medium' />}
-            >
-              <Trans>Wishlist</Trans>
-            </WishlistMenuFabItem>,
-            <DarkLightModeMenuSecondaryItem key='darkmode' />,
-            <StoreSwitcherMenuFabSecondaryItem key='store-switcher' />,
-          ],
-          [menu, selection],
-        )}
-      >
-        <NavigationOverlay
-          stretchColumns={false}
-          variantSm='left'
-          sizeSm='full'
-          justifySm='start'
-          itemWidthSm='70vw'
-          variantMd='left'
-          sizeMd='full'
-          justifyMd='start'
-          itemWidthMd='230px'
-          mouseEvent='hover'
-          itemPadding='md'
-        />
-      </NavigationProvider>
+      <MenuOverlay menu={menu} selection={selection} />
 
       <LayoutDefault
         {...uiProps}
         noSticky={router.asPath.split('?')[0] === '/'}
-        header={
-          <>
-            <Logo />
-
-            <DesktopNavBar>
-              {menu?.items?.[0]?.children?.slice(0, 2).map((item) => (
-                <DesktopNavItem key={item?.uid} href={`/${item?.url_path}`}>
-                  {item?.name}
-                </DesktopNavItem>
-              ))}
-              <DesktopNavItem
-                onClick={() => selection.set([menu?.items?.[0]?.uid || ''])}
-                onKeyUp={(evt) => {
-                  if (evt.key === 'Enter') {
-                    selection.set([menu?.items?.[0]?.uid || ''])
-                  }
-                }}
-                tabIndex={0}
-              >
-                {menu?.items?.[0]?.name}
-                <IconSvg src={iconChevronDown} />
-              </DesktopNavItem>
-            </DesktopNavBar>
-            <DesktopNavActions>
-              <StoreSwitcherButton />
-              <SearchField
-                formControl={{ sx: { width: '400px' } }}
-                searchField={{ productListRenderer }}
-              />
-              <Fab href='/service' aria-label={t`Customer Service`} size='large' color='inherit'>
-                <IconSvg src={iconCustomerService} size='large' />
-              </Fab>
-              <WishlistFab
-                icon={<IconSvg src={iconHeart} size='large' />}
-                BadgeProps={{ color: 'secondary' }}
-              />
-              <CustomerFab
-                guestHref='/account/signin'
-                authHref='/account'
-                BadgeProps={{ color: 'secondary' }}
-              />
-              {/* The placeholder exists because the CartFab is sticky but we want to reserve the space for the <CartFab /> */}
-              {cartEnabled && <PlaceholderFab />}
-            </DesktopNavActions>
-
-            <MobileTopRight>
-              <StoreSwitcherFab size='responsiveMedium' />
-              <SearchFab size='responsiveMedium' />
-            </MobileTopRight>
-          </>
-        }
+        header={<Header menu={menu} selection={selection} />}
         footer={
           <Footer
             socialLinks={

--- a/examples/magento-open-source/components/Layout/LayoutNavigation.tsx
+++ b/examples/magento-open-source/components/Layout/LayoutNavigation.tsx
@@ -9,7 +9,6 @@ import {
   StoreSwitcherMenuFabSecondaryItem,
 } from '@graphcommerce/magento-store'
 import { WishlistFab, WishlistMenuFabItem } from '@graphcommerce/magento-wishlist'
-import type { LayoutDefaultProps } from '@graphcommerce/next-ui'
 import {
   DarkLightModeMenuSecondaryItem,
   DesktopNavActions,
@@ -19,7 +18,6 @@ import {
   iconCustomerService,
   iconHeart,
   IconSvg,
-  LayoutDefault,
   MenuFabSecondaryItem,
   MobileTopRight,
   NavigationFab,
@@ -36,6 +34,7 @@ import { useRouter } from 'next/router'
 import { productListRenderer } from '../ProductListItems/productListRenderer'
 import { Footer } from './Footer'
 import type { LayoutQuery } from './Layout.gql'
+import { LayoutDefault, type LayoutDefaultProps } from './LayoutDefault'
 import { Logo } from './Logo'
 
 export type LayoutNavigationProps = LayoutQuery &

--- a/examples/magento-open-source/components/Layout/MenuOverlay.tsx
+++ b/examples/magento-open-source/components/Layout/MenuOverlay.tsx
@@ -1,0 +1,86 @@
+import { magentoMenuToNavigation } from '@graphcommerce/magento-category'
+import { CustomerMenuFabItem } from '@graphcommerce/magento-customer'
+import { StoreSwitcherMenuFabSecondaryItem } from '@graphcommerce/magento-store'
+import { WishlistMenuFabItem } from '@graphcommerce/magento-wishlist'
+import {
+  DarkLightModeMenuSecondaryItem,
+  iconCustomerService,
+  iconHeart,
+  IconSvg,
+  MenuFabSecondaryItem,
+  NavigationOverlay,
+  NavigationProvider,
+  useMemoDeep,
+  type UseNavigationSelection,
+} from '@graphcommerce/next-ui'
+import { Trans } from '@lingui/react/macro'
+import { Divider } from '@mui/material'
+import type { LayoutQuery } from './Layout.gql'
+
+export type MenuOverlayProps = LayoutQuery & { selection: UseNavigationSelection }
+
+export function MenuOverlay(props: MenuOverlayProps) {
+  const { menu, selection } = props
+
+  return (
+    <NavigationProvider
+      selection={selection}
+      items={useMemoDeep(
+        () => [
+          { id: 'home', name: <Trans>Home</Trans>, href: '/' },
+          {
+            id: 'manual-item-one',
+            href: `/${menu?.items?.[0]?.children?.[0]?.url_path}`,
+            name: menu?.items?.[0]?.children?.[0]?.name ?? '',
+          },
+          {
+            id: 'manual-item-two',
+            href: `/${menu?.items?.[0]?.children?.[1]?.url_path}`,
+            name: menu?.items?.[0]?.children?.[1]?.name ?? '',
+          },
+          ...magentoMenuToNavigation(menu, true),
+          <Divider key='divider' sx={(theme) => ({ my: theme.spacings.xs })} />,
+          <CustomerMenuFabItem
+            onClick={() => selection.set(false)}
+            key='account'
+            guestHref='/account/signin'
+            authHref='/account'
+          >
+            <Trans>Account</Trans>
+          </CustomerMenuFabItem>,
+          <MenuFabSecondaryItem
+            key='service'
+            icon={<IconSvg src={iconCustomerService} size='medium' />}
+            href='/service'
+          >
+            <Trans>Customer Service</Trans>
+          </MenuFabSecondaryItem>,
+          <WishlistMenuFabItem
+            onClick={() => selection.set(false)}
+            key='wishlist'
+            icon={<IconSvg src={iconHeart} size='medium' />}
+          >
+            <Trans>Wishlist</Trans>
+          </WishlistMenuFabItem>,
+          <DarkLightModeMenuSecondaryItem key='darkmode' />,
+          <StoreSwitcherMenuFabSecondaryItem key='store-switcher' />,
+        ],
+        [menu, selection],
+      )}
+    >
+      <NavigationOverlay
+        stretchColumns={false}
+        variantSm='left'
+        sizeSm='full'
+        justifySm='start'
+        itemWidthSm='70vw'
+        variantMd='left'
+        sizeMd='full'
+        justifyMd='start'
+        itemWidthMd='230px'
+        mouseEvent='hover'
+        itemPadding='md'
+      />
+    </NavigationProvider>
+  )
+}

--- a/examples/magento-storyblok/components/Layout/Header.tsx
+++ b/examples/magento-storyblok/components/Layout/Header.tsx
@@ -1,0 +1,89 @@
+import { useCartEnabled } from '@graphcommerce/magento-cart'
+import { CustomerFab } from '@graphcommerce/magento-customer'
+import { SearchFab, SearchField } from '@graphcommerce/magento-search'
+import { StoreSwitcherButton, StoreSwitcherFab } from '@graphcommerce/magento-store'
+import { WishlistFab } from '@graphcommerce/magento-wishlist'
+import {
+  DesktopNavActions,
+  DesktopNavBar,
+  DesktopNavItem,
+  iconChevronDown,
+  iconCustomerService,
+  iconHeart,
+  IconSvg,
+  MobileTopRight,
+  PlaceholderFab,
+  type UseNavigationSelection,
+} from '@graphcommerce/next-ui'
+import { t } from '@lingui/core/macro'
+import { Trans } from '@lingui/react/macro'
+import { Fab } from '@mui/material'
+import { productListRenderer } from '../ProductListItems/productListRenderer'
+import { HeaderContainer } from './HeaderContainer'
+import type { LayoutQuery } from './Layout.gql'
+import { Logo } from './Logo'
+
+export type HeaderProps = LayoutQuery & { selection: UseNavigationSelection }
+
+export function Header(props: HeaderProps) {
+  const { menu, selection } = props
+  const cartEnabled = useCartEnabled()
+
+  return (
+    <HeaderContainer>
+      <Logo />
+
+      <DesktopNavBar>
+        {menu?.items?.[0]?.children?.slice(0, 2).map((item) => (
+          <DesktopNavItem key={item?.uid} href={`/${item?.url_path}`}>
+            {item?.name}
+          </DesktopNavItem>
+        ))}
+
+        <DesktopNavItem
+          onClick={() => selection.set([menu?.items?.[0]?.uid || ''])}
+          onKeyUp={(evt) => {
+            if (evt.key === 'Enter') {
+              selection.set([menu?.items?.[0]?.uid || ''])
+            }
+          }}
+          tabIndex={0}
+        >
+          {menu?.items?.[0]?.name}
+          <IconSvg src={iconChevronDown} />
+        </DesktopNavItem>
+
+        <DesktopNavItem href='/blog'>
+          <Trans>Blog</Trans>
+        </DesktopNavItem>
+      </DesktopNavBar>
+
+      <DesktopNavActions>
+        <StoreSwitcherButton />
+        <SearchField
+          formControl={{ sx: { width: '400px' } }}
+          searchField={{ productListRenderer }}
+        />
+        <Fab href='/service' aria-label={t`Customer Service`} size='large' color='inherit'>
+          <IconSvg src={iconCustomerService} size='large' />
+        </Fab>
+        <WishlistFab
+          icon={<IconSvg src={iconHeart} size='large' />}
+          BadgeProps={{ color: 'secondary' }}
+        />
+        <CustomerFab
+          guestHref='/account/signin'
+          authHref='/account'
+          BadgeProps={{ color: 'secondary' }}
+        />
+        {/* The placeholder exists because the CartFab is sticky but we want to reserve the space for the <CartFab /> */}
+        {cartEnabled && <PlaceholderFab />}
+      </DesktopNavActions>
+
+      <MobileTopRight>
+        <StoreSwitcherFab size='responsiveMedium' />
+        <SearchFab size='responsiveMedium' />
+      </MobileTopRight>
+    </HeaderContainer>
+  )
+}

--- a/examples/magento-storyblok/components/Layout/HeaderContainer.tsx
+++ b/examples/magento-storyblok/components/Layout/HeaderContainer.tsx
@@ -1,0 +1,45 @@
+import type { ContainerSizingProps } from '@graphcommerce/next-ui'
+import { Container, sxx } from '@graphcommerce/next-ui'
+
+export type HeaderContainerProps = ContainerSizingProps
+
+export function HeaderContainer(props: HeaderContainerProps) {
+  const { children, sx, ...containerProps } = props
+  return (
+    <Container
+      sizing='shell'
+      maxWidth={false}
+      component='header'
+      {...containerProps}
+      sx={sxx(
+        (theme) => ({
+          zIndex: theme.zIndex.appBar - 1,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          height: theme.appShell.headerHeightSm,
+          pointerEvents: 'none',
+          '& > *': {
+            pointerEvents: 'all',
+          },
+          [theme.breakpoints.up('md')]: {
+            height: theme.appShell.headerHeightMd,
+            top: 0,
+            display: 'flex',
+            justifyContent: 'left',
+            width: '100%',
+          },
+          '&.sticky': {
+            [theme.breakpoints.down('md')]: {
+              position: 'sticky',
+              top: 0,
+            },
+          },
+        }),
+        sx,
+      )}
+    >
+      {children}
+    </Container>
+  )
+}

--- a/examples/magento-storyblok/components/Layout/LayoutDefault.tsx
+++ b/examples/magento-storyblok/components/Layout/LayoutDefault.tsx
@@ -75,38 +75,7 @@ export function LayoutDefault(props: LayoutDefaultProps) {
       <SkipLink />
       <LayoutProvider scroll={scrollYOffset}>
         {beforeHeader}
-        <Container
-          sizing='shell'
-          maxWidth={false}
-          component='header'
-          className={classes.header}
-          sx={(theme) => ({
-            zIndex: theme.zIndex.appBar - 1,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            height: theme.appShell.headerHeightSm,
-            pointerEvents: 'none',
-            '& > *': {
-              pointerEvents: 'all',
-            },
-            [theme.breakpoints.up('md')]: {
-              height: theme.appShell.headerHeightMd,
-              top: 0,
-              display: 'flex',
-              justifyContent: 'left',
-              width: '100%',
-            },
-            '&.sticky': {
-              [theme.breakpoints.down('md')]: {
-                position: 'sticky',
-                top: 0,
-              },
-            },
-          })}
-        >
-          {header}
-        </Container>
+        {header}
         {menuFab || cartFab ? (
           <Container
             sizing='shell'

--- a/examples/magento-storyblok/components/Layout/LayoutDefault.tsx
+++ b/examples/magento-storyblok/components/Layout/LayoutDefault.tsx
@@ -1,0 +1,165 @@
+import { useScrollOffset } from '@graphcommerce/framer-next-pages'
+import { dvh } from '@graphcommerce/framer-utils'
+import {
+  Container,
+  extendableComponent,
+  LayoutProvider,
+  SkipLink,
+  sxx,
+  useFabSize,
+} from '@graphcommerce/next-ui'
+import type { SxProps, Theme } from '@mui/material'
+import { Box } from '@mui/material'
+import { useScroll, useTransform } from 'framer-motion'
+
+export type LayoutDefaultProps = {
+  className?: string
+  beforeHeader?: React.ReactNode
+  header: React.ReactNode
+  footer: React.ReactNode
+  menuFab?: React.ReactNode
+  cartFab?: React.ReactNode
+  children?: React.ReactNode
+  noSticky?: boolean
+  sx?: SxProps<Theme>
+} & OwnerState
+
+type OwnerState = {
+  noSticky?: boolean
+}
+const parts = ['root', 'fabs', 'header', 'children', 'footer'] as const
+const { withState } = extendableComponent<OwnerState, 'LayoutDefault', typeof parts>(
+  'LayoutDefault',
+  parts,
+)
+
+export function LayoutDefault(props: LayoutDefaultProps) {
+  const {
+    children,
+    header,
+    beforeHeader,
+    footer,
+    menuFab,
+    cartFab,
+    noSticky,
+    className,
+    sx = [],
+  } = props
+
+  const { scrollY } = useScroll()
+  const scrollYOffset = useTransform(
+    [scrollY, useScrollOffset()],
+    ([y, offset]: number[]) => y + offset,
+  )
+
+  const classes = withState({ noSticky })
+  const fabIconSize = useFabSize('responsive')
+
+  return (
+    <Box
+      className={`${classes.root} ${className ?? ''}`}
+      sx={sxx(
+        (theme) => ({
+          minHeight: dvh(100),
+          '@supports (-webkit-touch-callout: none)': {
+            minHeight: '-webkit-fill-available',
+          },
+          display: 'grid',
+          gridTemplateRows: { xs: 'auto 1fr auto', md: 'auto auto 1fr auto' },
+          gridTemplateColumns: '100%',
+          background: theme.vars.palette.background.default,
+        }),
+        sx,
+      )}
+    >
+      <SkipLink />
+      <LayoutProvider scroll={scrollYOffset}>
+        {beforeHeader}
+        <Container
+          sizing='shell'
+          maxWidth={false}
+          component='header'
+          className={classes.header}
+          sx={(theme) => ({
+            zIndex: theme.zIndex.appBar - 1,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            height: theme.appShell.headerHeightSm,
+            pointerEvents: 'none',
+            '& > *': {
+              pointerEvents: 'all',
+            },
+            [theme.breakpoints.up('md')]: {
+              height: theme.appShell.headerHeightMd,
+              top: 0,
+              display: 'flex',
+              justifyContent: 'left',
+              width: '100%',
+            },
+            '&.sticky': {
+              [theme.breakpoints.down('md')]: {
+                position: 'sticky',
+                top: 0,
+              },
+            },
+          })}
+        >
+          {header}
+        </Container>
+        {menuFab || cartFab ? (
+          <Container
+            sizing='shell'
+            maxWidth={false}
+            className={classes.fabs}
+            sx={(theme) => ({
+              display: 'flex',
+              justifyContent: 'space-between',
+              width: '100%',
+              height: 0,
+              zIndex: 'speedDial',
+              [theme.breakpoints.up('sm')]: {
+                position: 'sticky',
+                marginTop: `calc(${theme.appShell.headerHeightMd} * -1 - calc(${fabIconSize} / 2))`,
+                top: `calc(${theme.appShell.headerHeightMd} / 2 - (${fabIconSize} / 2))`,
+              },
+              [theme.breakpoints.down('md')]: {
+                position: 'fixed',
+                top: 'unset',
+                bottom: `calc(20px + ${fabIconSize})`,
+                padding: '0 20px',
+                '@media (max-height: 530px) and (orientation: portrait)': {
+                  display: 'none',
+                },
+              },
+            })}
+          >
+            {menuFab}
+            {cartFab && (
+              <Box
+                sx={(theme) => ({
+                  display: 'flex',
+                  flexDirection: 'row-reverse',
+                  gap: theme.spacings.sm,
+                  [theme.breakpoints.up('md')]: {
+                    flexDirection: 'column',
+                    alignItems: 'flex-end',
+                  },
+                })}
+              >
+                {cartFab}
+              </Box>
+            )}
+          </Container>
+        ) : (
+          <div />
+        )}
+        <div className={classes.children}>
+          <div id='skip-nav' tabIndex={-1} />
+          {children}
+        </div>
+        <div className={classes.footer}>{footer}</div>
+      </LayoutProvider>
+    </Box>
+  )
+}

--- a/examples/magento-storyblok/components/Layout/LayoutMinimal.tsx
+++ b/examples/magento-storyblok/components/Layout/LayoutMinimal.tsx
@@ -1,9 +1,9 @@
-import type { LayoutDefaultProps } from '@graphcommerce/next-ui'
-import { LayoutDefault } from '@graphcommerce/next-ui'
 import { GlobalConfigProvider } from '../Storyblok/GlobalConfigProvider'
 import type { StoryblokGlobalConfig } from '../Storyblok/types'
 import { Footer } from './Footer'
+import { HeaderContainer } from './HeaderContainer'
 import type { LayoutQuery } from './Layout.gql'
+import { LayoutDefault, type LayoutDefaultProps } from './LayoutDefault'
 import { Logo } from './Logo'
 
 export type LayoutMinimalProps = LayoutQuery &
@@ -18,7 +18,11 @@ export function LayoutMinimal(props: LayoutMinimalProps) {
     <GlobalConfigProvider value={globalConfig}>
       <LayoutDefault
         {...uiProps}
-        header={<Logo />}
+        header={
+          <HeaderContainer>
+            <Logo />
+          </HeaderContainer>
+        }
         footer={<Footer />}
         sx={(theme) => ({ background: theme.vars.palette.background.paper })}
       >

--- a/examples/magento-storyblok/components/Layout/LayoutNavigation.tsx
+++ b/examples/magento-storyblok/components/Layout/LayoutNavigation.tsx
@@ -8,7 +8,6 @@ import {
   StoreSwitcherMenuFabSecondaryItem,
 } from '@graphcommerce/magento-store'
 import { WishlistFab, WishlistMenuFabItem } from '@graphcommerce/magento-wishlist'
-import type { LayoutDefaultProps } from '@graphcommerce/next-ui'
 import {
   DarkLightModeMenuSecondaryItem,
   DesktopNavActions,
@@ -18,7 +17,6 @@ import {
   iconCustomerService,
   iconHeart,
   IconSvg,
-  LayoutDefault,
   MenuFabSecondaryItem,
   MobileTopRight,
   NavigationFab,
@@ -37,6 +35,7 @@ import { GlobalConfigProvider } from '../Storyblok/GlobalConfigProvider'
 import type { StoryblokGlobalConfig } from '../Storyblok/types'
 import { Footer } from './Footer'
 import type { LayoutQuery } from './Layout.gql'
+import { LayoutDefault, type LayoutDefaultProps } from './LayoutDefault'
 import { Logo } from './Logo'
 
 export type LayoutNavigationProps = LayoutQuery &

--- a/examples/magento-storyblok/components/Layout/LayoutNavigation.tsx
+++ b/examples/magento-storyblok/components/Layout/LayoutNavigation.tsx
@@ -1,42 +1,13 @@
-import { CartFab, useCartEnabled } from '@graphcommerce/magento-cart'
-import { magentoMenuToNavigation } from '@graphcommerce/magento-category'
-import { CustomerFab, CustomerMenuFabItem } from '@graphcommerce/magento-customer'
-import { SearchFab, SearchField } from '@graphcommerce/magento-search'
-import {
-  StoreSwitcherButton,
-  StoreSwitcherFab,
-  StoreSwitcherMenuFabSecondaryItem,
-} from '@graphcommerce/magento-store'
-import { WishlistFab, WishlistMenuFabItem } from '@graphcommerce/magento-wishlist'
-import {
-  DarkLightModeMenuSecondaryItem,
-  DesktopNavActions,
-  DesktopNavBar,
-  DesktopNavItem,
-  iconChevronDown,
-  iconCustomerService,
-  iconHeart,
-  IconSvg,
-  MenuFabSecondaryItem,
-  MobileTopRight,
-  NavigationFab,
-  NavigationOverlay,
-  NavigationProvider,
-  PlaceholderFab,
-  useMemoDeep,
-  useNavigationSelection,
-} from '@graphcommerce/next-ui'
-import { t } from '@lingui/core/macro'
-import { Trans } from '@lingui/react/macro'
-import { Divider, Fab } from '@mui/material'
+import { CartFab } from '@graphcommerce/magento-cart'
+import { NavigationFab, useNavigationSelection } from '@graphcommerce/next-ui'
 import { useRouter } from 'next/router'
-import { productListRenderer } from '../ProductListItems/productListRenderer'
 import { GlobalConfigProvider } from '../Storyblok/GlobalConfigProvider'
 import type { StoryblokGlobalConfig } from '../Storyblok/types'
 import { Footer } from './Footer'
+import { Header } from './Header'
 import type { LayoutQuery } from './Layout.gql'
 import { LayoutDefault, type LayoutDefaultProps } from './LayoutDefault'
-import { Logo } from './Logo'
+import { MenuOverlay } from './MenuOverlay'
 
 export type LayoutNavigationProps = LayoutQuery &
   Omit<LayoutDefaultProps, 'footer' | 'header' | 'cartFab' | 'menuFab'> & {
@@ -49,129 +20,14 @@ export function LayoutNavigation(props: LayoutNavigationProps) {
   const selection = useNavigationSelection()
   const router = useRouter()
 
-  const cartEnabled = useCartEnabled()
-
   return (
     <GlobalConfigProvider value={globalConfig}>
-      <NavigationProvider
-        selection={selection}
-        items={useMemoDeep(
-          () => [
-            { id: 'home', name: <Trans>Home</Trans>, href: '/' },
-            {
-              id: 'manual-item-one',
-              href: `/${menu?.items?.[0]?.children?.[0]?.url_path}`,
-              name: menu?.items?.[0]?.children?.[0]?.name ?? '',
-            },
-            {
-              id: 'manual-item-two',
-              href: `/${menu?.items?.[0]?.children?.[1]?.url_path}`,
-              name: menu?.items?.[0]?.children?.[1]?.name ?? '',
-            },
-            ...magentoMenuToNavigation(menu, true),
-            { id: 'blog', name: 'Blog', href: '/blog' },
-            <Divider key='divider' sx={(theme) => ({ my: theme.spacings.xs })} />,
-            <CustomerMenuFabItem
-              onClick={() => selection.set(false)}
-              key='account'
-              guestHref='/account/signin'
-              authHref='/account'
-            >
-              <Trans>Account</Trans>
-            </CustomerMenuFabItem>,
-            <MenuFabSecondaryItem
-              key='service'
-              icon={<IconSvg src={iconCustomerService} size='medium' />}
-              href='/service'
-            >
-              <Trans>Customer Service</Trans>
-            </MenuFabSecondaryItem>,
-            <WishlistMenuFabItem
-              onClick={() => selection.set(false)}
-              key='wishlist'
-              icon={<IconSvg src={iconHeart} size='medium' />}
-            >
-              <Trans>Wishlist</Trans>
-            </WishlistMenuFabItem>,
-            <DarkLightModeMenuSecondaryItem key='darkmode' />,
-            <StoreSwitcherMenuFabSecondaryItem key='store-switcher' />,
-          ],
-          [menu, selection],
-        )}
-      >
-        <NavigationOverlay
-          stretchColumns={false}
-          variantSm='left'
-          sizeSm='full'
-          justifySm='start'
-          itemWidthSm='70vw'
-          variantMd='left'
-          sizeMd='full'
-          justifyMd='start'
-          itemWidthMd='230px'
-          mouseEvent='hover'
-          itemPadding='md'
-        />
-      </NavigationProvider>
+      <MenuOverlay menu={menu} selection={selection} />
 
       <LayoutDefault
         {...uiProps}
         noSticky={router.asPath.split('?')[0] === '/'}
-        header={
-          <>
-            <Logo />
-
-            <DesktopNavBar>
-              {menu?.items?.[0]?.children?.slice(0, 2).map((item) => (
-                <DesktopNavItem key={item?.uid} href={`/${item?.url_path}`}>
-                  {item?.name}
-                </DesktopNavItem>
-              ))}
-              <DesktopNavItem
-                onClick={() => selection.set([menu?.items?.[0]?.uid || ''])}
-                onKeyUp={(evt) => {
-                  if (evt.key === 'Enter') {
-                    selection.set([menu?.items?.[0]?.uid || ''])
-                  }
-                }}
-                tabIndex={0}
-              >
-                {menu?.items?.[0]?.name}
-                <IconSvg src={iconChevronDown} />
-              </DesktopNavItem>
-
-              <DesktopNavItem href='/blog'>
-                <Trans>Blog</Trans>
-              </DesktopNavItem>
-            </DesktopNavBar>
-            <DesktopNavActions>
-              <StoreSwitcherButton />
-              <SearchField
-                formControl={{ sx: { width: '400px' } }}
-                searchField={{ productListRenderer }}
-              />
-              <Fab href='/service' aria-label={t`Customer Service`} size='large' color='inherit'>
-                <IconSvg src={iconCustomerService} size='large' />
-              </Fab>
-              <WishlistFab
-                icon={<IconSvg src={iconHeart} size='large' />}
-                BadgeProps={{ color: 'secondary' }}
-              />
-              <CustomerFab
-                guestHref='/account/signin'
-                authHref='/account'
-                BadgeProps={{ color: 'secondary' }}
-              />
-              {/* The placeholder exists because the CartFab is sticky but we want to reserve the space for the <CartFab /> */}
-              {cartEnabled && <PlaceholderFab />}
-            </DesktopNavActions>
-
-            <MobileTopRight>
-              <StoreSwitcherFab size='responsiveMedium' />
-              <SearchFab size='responsiveMedium' />
-            </MobileTopRight>
-          </>
-        }
+        header={<Header menu={menu} selection={selection} />}
         footer={<Footer />}
         cartFab={<CartFab BadgeProps={{ color: 'secondary' }} />}
         menuFab={<NavigationFab onClick={() => selection.set([])} />}

--- a/examples/magento-storyblok/components/Layout/MenuOverlay.tsx
+++ b/examples/magento-storyblok/components/Layout/MenuOverlay.tsx
@@ -1,0 +1,87 @@
+import { magentoMenuToNavigation } from '@graphcommerce/magento-category'
+import { CustomerMenuFabItem } from '@graphcommerce/magento-customer'
+import { StoreSwitcherMenuFabSecondaryItem } from '@graphcommerce/magento-store'
+import { WishlistMenuFabItem } from '@graphcommerce/magento-wishlist'
+import {
+  DarkLightModeMenuSecondaryItem,
+  iconCustomerService,
+  iconHeart,
+  IconSvg,
+  MenuFabSecondaryItem,
+  NavigationOverlay,
+  NavigationProvider,
+  useMemoDeep,
+  type UseNavigationSelection,
+} from '@graphcommerce/next-ui'
+import { Trans } from '@lingui/react/macro'
+import { Divider } from '@mui/material'
+import type { LayoutQuery } from './Layout.gql'
+
+export type MenuOverlayProps = LayoutQuery & { selection: UseNavigationSelection }
+
+export function MenuOverlay(props: MenuOverlayProps) {
+  const { menu, selection } = props
+
+  return (
+    <NavigationProvider
+      selection={selection}
+      items={useMemoDeep(
+        () => [
+          { id: 'home', name: <Trans>Home</Trans>, href: '/' },
+          {
+            id: 'manual-item-one',
+            href: `/${menu?.items?.[0]?.children?.[0]?.url_path}`,
+            name: menu?.items?.[0]?.children?.[0]?.name ?? '',
+          },
+          {
+            id: 'manual-item-two',
+            href: `/${menu?.items?.[0]?.children?.[1]?.url_path}`,
+            name: menu?.items?.[0]?.children?.[1]?.name ?? '',
+          },
+          ...magentoMenuToNavigation(menu, true),
+          { id: 'blog', name: 'Blog', href: '/blog' },
+          <Divider key='divider' sx={(theme) => ({ my: theme.spacings.xs })} />,
+          <CustomerMenuFabItem
+            onClick={() => selection.set(false)}
+            key='account'
+            guestHref='/account/signin'
+            authHref='/account'
+          >
+            <Trans>Account</Trans>
+          </CustomerMenuFabItem>,
+          <MenuFabSecondaryItem
+            key='service'
+            icon={<IconSvg src={iconCustomerService} size='medium' />}
+            href='/service'
+          >
+            <Trans>Customer Service</Trans>
+          </MenuFabSecondaryItem>,
+          <WishlistMenuFabItem
+            onClick={() => selection.set(false)}
+            key='wishlist'
+            icon={<IconSvg src={iconHeart} size='medium' />}
+          >
+            <Trans>Wishlist</Trans>
+          </WishlistMenuFabItem>,
+          <DarkLightModeMenuSecondaryItem key='darkmode' />,
+          <StoreSwitcherMenuFabSecondaryItem key='store-switcher' />,
+        ],
+        [menu, selection],
+      )}
+    >
+      <NavigationOverlay
+        stretchColumns={false}
+        variantSm='left'
+        sizeSm='full'
+        justifySm='start'
+        itemWidthSm='70vw'
+        variantMd='left'
+        sizeMd='full'
+        justifyMd='start'
+        itemWidthMd='230px'
+        mouseEvent='hover'
+        itemPadding='md'
+      />
+    </NavigationProvider>
+  )
+}

--- a/packages/magento-cart/components/CartFab/CartFab.tsx
+++ b/packages/magento-cart/components/CartFab/CartFab.tsx
@@ -15,12 +15,14 @@ import React from 'react'
 import { useCartEnabled, useCartShouldLoginToContinue } from '../../hooks'
 import { useCartQuery } from '../../hooks/useCartQuery'
 import { CartFabDocument } from './CartFab.gql'
+import { CartFabStatic } from './CartFabStatic'
 import type { CartTotalQuantityFragment } from './CartTotalQuantity.gql'
 
 export type CartFabProps = {
   icon?: React.ReactNode
   sx?: SxProps<Theme>
   BadgeProps?: BadgeProps
+  disableScrollEffects?: boolean
 } & Pick<FabProps, 'color' | 'size' | 'variant'>
 
 export type CartFabContentProps = CartFabProps & CartTotalQuantityFragment
@@ -108,5 +110,9 @@ export function CartFab(props: CartFabProps) {
   })
   if (!cartEnabled) return null
 
-  return <CartFabContent total_quantity={cartQuery.data?.cart?.total_quantity ?? 0} {...props} />
+  const { disableScrollEffects, ...rest } = props
+  if (disableScrollEffects)
+    return <CartFabStatic total_quantity={cartQuery.data?.cart?.total_quantity ?? 0} {...rest} />
+
+  return <CartFabContent total_quantity={cartQuery.data?.cart?.total_quantity ?? 0} {...rest} />
 }

--- a/packages/magento-cart/components/CartFab/CartFabStatic.tsx
+++ b/packages/magento-cart/components/CartFab/CartFabStatic.tsx
@@ -1,0 +1,49 @@
+import {
+  DesktopHeaderBadge,
+  extendableComponent,
+  iconShoppingBag,
+  IconSvg,
+  sxx,
+} from '@graphcommerce/next-ui'
+import { t } from '@lingui/core/macro'
+import { Fab } from '@mui/material'
+import type { CartFabContentProps } from './CartFab'
+
+export type CartFabStaticProps = Omit<CartFabContentProps, 'disableScrollEffects'>
+
+const { classes } = extendableComponent('CartFab', ['root', 'cart', 'shadow'] as const)
+
+export function CartFabStatic(props: CartFabStaticProps) {
+  const { total_quantity, icon, sx = [], BadgeProps, ...fabProps } = props
+
+  const cartIcon = icon ?? <IconSvg src={iconShoppingBag} size='large' />
+
+  return (
+    <Fab
+      href='/cart'
+      className={classes.cart}
+      aria-label={t`Cart`}
+      color='inherit'
+      size='responsive'
+      sx={sxx(
+        (theme) => ({
+          [theme.breakpoints.down('md')]: {
+            backgroundColor: theme.vars.palette.background.paper,
+          },
+        }),
+        sx,
+      )}
+      {...fabProps}
+    >
+      <DesktopHeaderBadge
+        color='primary'
+        variant='dot'
+        overlap='circular'
+        badgeContent={total_quantity}
+        {...BadgeProps}
+      >
+        {cartIcon}
+      </DesktopHeaderBadge>
+    </Fab>
+  )
+}

--- a/packages/next-ui/Footer/Footer.tsx
+++ b/packages/next-ui/Footer/Footer.tsx
@@ -1,7 +1,7 @@
 import { sxx } from '@graphcommerce/next-ui'
-import type { ContainerProps } from '@mui/material'
 import { Box } from '@mui/material'
-import React from 'react'
+import type React from 'react'
+import type { ContainerSizingProps } from '../Container/Container'
 import { Container } from '../Container/Container'
 import { LazyHydrate } from '../LazyHydrate'
 import { extendableComponent } from '../Styles'
@@ -12,7 +12,7 @@ export type FooterProps = {
   customerService?: React.ReactNode
   copyright?: React.ReactNode
   children?: React.ReactNode
-} & ContainerProps
+} & ContainerSizingProps
 
 const { classes, selectors } = extendableComponent('Footer', [
   'root',

--- a/packages/next-ui/LayoutDefault/components/LayoutDefault.tsx
+++ b/packages/next-ui/LayoutDefault/components/LayoutDefault.tsx
@@ -10,6 +10,10 @@ import { SkipLink } from '../../SkipLink/SkipLink'
 import { extendableComponent } from '../../Styles'
 import { useFabSize } from '../../Theme'
 
+/**
+ * @deprecated Import `LayoutDefaultProps` from your project's
+ * `components/Layout/LayoutDefault.tsx` instead.
+ */
 export type LayoutDefaultProps = {
   className?: string
   beforeHeader?: React.ReactNode
@@ -31,6 +35,10 @@ const { withState } = extendableComponent<OwnerState, 'LayoutDefault', typeof pa
   parts,
 )
 
+/**
+ * @deprecated Import `LayoutDefault` from your project's
+ * `components/Layout/LayoutDefault.tsx` instead.
+ */
 export function LayoutDefault(props: LayoutDefaultProps) {
   const {
     children,

--- a/packages/next-ui/Navigation/components/NavigationFab.tsx
+++ b/packages/next-ui/Navigation/components/NavigationFab.tsx
@@ -81,16 +81,22 @@ export function NavigationFab(props: NavigationFabProps) {
           color='inherit'
           aria-label='Open Menu'
           size='responsive'
-          sx={{
+          sx={sxx(
+            {
               boxShadow: 'none',
+              pointerEvents: 'all',
               '&:hover, &:focus': {
                 boxShadow: 'none',
+              },
+            },
+            !fabProps.color && {
+              '&:hover, &:focus': {
                 background: theme.vars.palette.text.primary,
               },
               background: theme.vars.palette.text.primary,
-            pointerEvents: 'all',
               color: theme.vars.palette.background.paper,
-          }}
+            },
+          )}
           className={classes.fab}
           {...fabProps}
         >

--- a/packages/next-ui/Navigation/components/NavigationFab.tsx
+++ b/packages/next-ui/Navigation/components/NavigationFab.tsx
@@ -17,6 +17,7 @@ const MotionDiv = styled(m.div)({})
 export type NavigationFabProps = {
   menuIcon?: React.ReactNode
   closeIcon?: React.ReactNode
+  disableScrollEffects?: boolean
   sx?: SxProps<Theme>
 } & Pick<FabProps, 'color' | 'size' | 'variant' | 'onClick'>
 
@@ -29,7 +30,7 @@ type OwnerState = {
 const { withState } = extendableComponent<OwnerState, typeof name, typeof parts>(name, parts)
 
 export function NavigationFab(props: NavigationFabProps) {
-  const { menuIcon, closeIcon, sx = [], ...fabProps } = props
+  const { menuIcon, closeIcon, disableScrollEffects, sx = [], ...fabProps } = props
   const router = useRouter()
   const [openEl, setOpenEl] = React.useState<null | HTMLElement>(null)
 
@@ -53,12 +54,19 @@ export function NavigationFab(props: NavigationFabProps) {
     <Box sx={sxx({ position: 'relative', width: fabIconSize, height: fabIconSize }, sx)}>
       <MotionDiv
         className={classes.wrapper}
-        sx={{
-          [theme.breakpoints.down('md')]: {
-            opacity: '1 !important',
-            transform: 'none !important',
-          },
-        }}
+        sx={
+          disableScrollEffects
+            ? {
+                opacity: '1 !important',
+                transform: 'none !important',
+              }
+            : {
+                [theme.breakpoints.down('md')]: {
+                  opacity: '1 !important',
+                  transform: 'none !important',
+                },
+              }
+        }
         style={{ opacity }}
       >
         <Fab
@@ -121,7 +129,7 @@ export function NavigationFab(props: NavigationFabProps) {
             [theme.breakpoints.down('md')]: { opacity: '1 !important' },
           }}
           className={classes.shadow}
-          style={{ opacity: shadowOpacity }}
+          style={disableScrollEffects ? undefined : { opacity: shadowOpacity }}
         />
       </MotionDiv>
     </Box>

--- a/packages/next-ui/Navigation/components/NavigationFab.tsx
+++ b/packages/next-ui/Navigation/components/NavigationFab.tsx
@@ -18,6 +18,7 @@ export type NavigationFabProps = {
   menuIcon?: React.ReactNode
   closeIcon?: React.ReactNode
   disableScrollEffects?: boolean
+  disableElevation?: boolean
   sx?: SxProps<Theme>
 } & Pick<FabProps, 'color' | 'size' | 'variant' | 'onClick'>
 
@@ -30,7 +31,14 @@ type OwnerState = {
 const { withState } = extendableComponent<OwnerState, typeof name, typeof parts>(name, parts)
 
 export function NavigationFab(props: NavigationFabProps) {
-  const { menuIcon, closeIcon, disableScrollEffects, sx = [], ...fabProps } = props
+  const {
+    menuIcon,
+    closeIcon,
+    disableScrollEffects,
+    disableElevation,
+    sx = [],
+    ...fabProps
+  } = props
   const router = useRouter()
   const [openEl, setOpenEl] = React.useState<null | HTMLElement>(null)
 
@@ -74,14 +82,14 @@ export function NavigationFab(props: NavigationFabProps) {
           aria-label='Open Menu'
           size='responsive'
           sx={{
-            boxShadow: 'none',
-            '&:hover, &:focus': {
               boxShadow: 'none',
+              '&:hover, &:focus': {
+                boxShadow: 'none',
+                background: theme.vars.palette.text.primary,
+              },
               background: theme.vars.palette.text.primary,
-            },
-            background: theme.vars.palette.text.primary,
             pointerEvents: 'all',
-            color: theme.vars.palette.background.paper,
+              color: theme.vars.palette.background.paper,
           }}
           className={classes.fab}
           {...fabProps}
@@ -117,20 +125,22 @@ export function NavigationFab(props: NavigationFabProps) {
             />
           )}
         </Fab>
-        <MotionDiv
-          sx={{
-            pointerEvents: 'none',
-            borderRadius: '99em',
-            position: 'absolute',
-            height: '100%',
-            width: '100%',
-            boxShadow: theme.shadows[6],
-            top: 0,
-            [theme.breakpoints.down('md')]: { opacity: '1 !important' },
-          }}
-          className={classes.shadow}
-          style={disableScrollEffects ? undefined : { opacity: shadowOpacity }}
-        />
+        {!disableElevation && (
+          <MotionDiv
+            sx={{
+              pointerEvents: 'none',
+              borderRadius: '99em',
+              position: 'absolute',
+              height: '100%',
+              width: '100%',
+              boxShadow: theme.shadows[6],
+              top: 0,
+              [theme.breakpoints.down('md')]: { opacity: '1 !important' },
+            }}
+            className={classes.shadow}
+            style={disableScrollEffects ? undefined : { opacity: shadowOpacity }}
+          />
+        )}
       </MotionDiv>
     </Box>
   )


### PR DESCRIPTION
## Summary

Refactors `LayoutNavigation` in the example storefronts from a single ~180-line file
into composable pieces and moves the canonical `LayoutDefault` from
`@graphcommerce/next-ui` into each project's `components/Layout/`. No visual change,
no breaking imports.

## What's in this PR

- **Split** `LayoutNavigation` into `Header/Header.tsx`, `Header/HeaderContainer.tsx`,
  `MenuOverlay.tsx`, and a project-local `LayoutDefault.tsx`. `HeaderContainer` is the
  `<Container component='header'>` wrapper lifted out of `LayoutDefault`, so each project
  fully owns its header container (sticky, mobile pointer-events, styling) without
  forking next-ui.
- **`LayoutMinimal`** uses the same local `LayoutDefault` + `HeaderContainer` as the
  canonical pattern.
- **`disableScrollEffects`** prop added to `CartFab` and `NavigationFab`, which makes
  it easier to drop them into a fully-custom header.
- **`@graphcommerce/next-ui`'s `LayoutDefault`** is marked `@deprecated`. The
  implementation stays in place; the deprecation only points consumers at the local copy
  they already have after a sync.