### PR TITLE
fix: fetch globalConfig on blog pages so global content renders

### DIFF
--- a/.changeset/mighty-pans-stick.md
+++ b/.changeset/mighty-pans-stick.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/magento-storyblok': patch
+---
+
+Fixed empty footer on blog pages

--- a/examples/magento-storyblok/pages/blog/[...url].tsx
+++ b/examples/magento-storyblok/pages/blog/[...url].tsx
@@ -30,7 +30,7 @@ import { BlogList, LayoutDocument, LayoutNavigation } from '../../components'
 import type { LayoutNavigationProps } from '../../components'
 import { RowRenderer } from '../../components/Storyblok/RowRenderer'
 import { graphqlSharedClient, graphqlSsrClient } from '../../lib/graphql/graphqlSsrClient'
-import { useStoryblokState } from '../../lib/storyblok'
+import { fetchGlobalConfig, useStoryblokState } from '../../lib/storyblok'
 
 type Props = { story: StoryblokStory | null; related: StoryblokStory[] }
 type RouteProps = { url: string[] }
@@ -140,6 +140,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
     fetchPolicy: cacheFirst(staticClient),
   })
 
+  const globalConfig = fetchGlobalConfig(context)
   const storyPage = fetchStory(slug, context, staticClient)
   const related = fetchStories({
     starts_with: 'blog/',
@@ -156,6 +157,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
       story,
       related: (await related).stories,
       ...(await layout).data,
+      globalConfig: (await globalConfig)?.content ?? null,
       up: { href: '/blog', title: t`Blog` },
       apolloState: await conf.then(() => client.cache.extract()),
     },

--- a/examples/magento-storyblok/pages/blog/page/[page].tsx
+++ b/examples/magento-storyblok/pages/blog/page/[page].tsx
@@ -24,7 +24,7 @@ import { BlogList, LayoutDocument, LayoutNavigation } from '../../../components'
 import type { LayoutNavigationProps } from '../../../components'
 import { RowRenderer } from '../../../components/Storyblok/RowRenderer'
 import { graphqlSharedClient, graphqlSsrClient } from '../../../lib/graphql/graphqlSsrClient'
-import { useStoryblokState } from '../../../lib/storyblok'
+import { fetchGlobalConfig, useStoryblokState } from '../../../lib/storyblok'
 
 type Props = {
   story: StoryblokStory | null
@@ -116,6 +116,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
     fetchPolicy: cacheFirst(staticClient),
   })
 
+  const globalConfig = fetchGlobalConfig(context)
   const landingStory = fetchStory('blog', context, staticClient)
   const blogList = fetchStories({
     starts_with: 'blog/',
@@ -136,6 +137,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
       total,
       perPage,
       ...(await layout).data,
+      globalConfig: (await globalConfig)?.content ?? null,
       apolloState: await conf.then(() => client.cache.extract()),
     },
     revalidate: revalidate(),

--- a/examples/magento-storyblok/pages/blog/tagged/[url].tsx
+++ b/examples/magento-storyblok/pages/blog/tagged/[url].tsx
@@ -20,6 +20,7 @@ import type { GetStaticPaths } from 'next'
 import { BlogList, LayoutDocument, LayoutNavigation } from '../../../components'
 import type { LayoutNavigationProps } from '../../../components'
 import { graphqlSharedClient, graphqlSsrClient } from '../../../lib/graphql/graphqlSsrClient'
+import { fetchGlobalConfig } from '../../../lib/storyblok'
 
 type Props = { tag: string; stories: StoryblokStory[] }
 type RouteProps = { url: string }
@@ -98,6 +99,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
     fetchPolicy: cacheFirst(staticClient),
   })
 
+  const globalConfig = fetchGlobalConfig(context)
   const stories = await fetchAllStories({
     starts_with: 'blog/',
     excluding_slugs: 'blog/,blog/tagged/*',
@@ -113,6 +115,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
       tag,
       stories,
       ...(await layout).data,
+      globalConfig: (await globalConfig)?.content ?? null,
       up: { href: '/blog', title: t`Blog` },
       apolloState: await conf.then(() => client.cache.extract()),
     },


### PR DESCRIPTION
Blog pages never fetched the global config in getStaticProps, so GlobalConfigProvider received undefined and the footer rendered empty. Add fetchGlobalConfig + globalConfig prop to the blog index/post/tagged pages, matching the pattern in pages/[...url].tsx.