### PR TITLE
fix(magento-product): count items with no customizable_options as added

### DIFF
--- a/.changeset/add-products-to-cart-empty-customizable-options.md
+++ b/.changeset/add-products-to-cart-empty-customizable-options.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/magento-product': patch
+---
+
+Fix the add-to-cart success message counting 0 when the added cart item has no `customizable_options` to match the requested entered/selected options against. `findAddedItems` now falls back to the SKU (+ configurable variant) match instead of dropping the item.

--- a/packages/magento-product/components/AddProductsToCart/findAddedItems.ts
+++ b/packages/magento-product/components/AddProductsToCart/findAddedItems.ts
@@ -48,6 +48,8 @@ export function findAddedItems(
       }
 
       const { customizable_options } = cartItem
+      // No customizable_options to match against — trust the SKU candidacy rather than drop the item.
+      if (customizable_options.length === 0) return true
       const matchEntered = filterNonNullableKeys(itemVariable.entered_options).every(
         (requestOption) =>
           customizable_options.find(


### PR DESCRIPTION
## Problem

The add-to-cart success snackbar reports **"0 products added"** for products whose backend consumes the submitted `entered_options`/`selected_options` into its own field instead of echoing them back as Magento `customizable_options`.

`findAddedItems` matches each submitted `cartItem` against the returned cart by SKU **and** requires every requested entered/selected option to round-trip through the cart item's `customizable_options`. When a backend integration (for example a 3D configurator that persists its state in a custom cart field) leaves `customizable_options` empty, that match fails, the — in fact added — item is dropped from `addedItems`, and `<Plural value={addedItems.length}>` renders the `other` ("0 products") branch.

Products that submit no `entered_options` (the common configurable/simple case) are unaffected, because the match is vacuously true for them.

## Fix

When the cart item carries no `customizable_options`, there is nothing to match the requested options against — so accept the SKU (+ configurable variant/options) candidacy already established earlier in the function rather than dropping the item.

```ts
const { customizable_options } = cartItem
// No customizable_options to match against — trust the SKU candidacy rather than drop the item.
if (customizable_options.length === 0) return true
```

## Notes

- Behaviour is unchanged whenever the cart item **does** expose `customizable_options` (the existing strict entered/selected matching still runs).
- Found while integrating a custom configurator on a GraphCommerce storefront; verified end-to-end that the success message now names the added product instead of "0 products".