### PR TITLE
Fix/i18n up breadcrumb locale race

### DIFF
--- a/.changeset/breadcrumb-up-locale-race.md
+++ b/.changeset/breadcrumb-up-locale-race.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/demo-magento-graphcommerce': patch
+---
+
+Fix breadcrumb "up" link title being translated in the wrong locale during static generation. The Lingui `t` macro title was evaluated inside the returned props after awaiting GraphQL queries, so a concurrent static-generation request for another locale could change the global active locale mid-flight. The `up` object is now computed synchronously before any await, capturing the correct locale for the current request.

--- a/examples/magento-graphcms/pages/404.tsx
+++ b/examples/magento-graphcms/pages/404.tsx
@@ -75,6 +75,7 @@ export default RouteNotFoundPage
 
 export const getStaticProps: GetPageStaticProps = async (context) => {
   const client = graphqlSharedClient(context)
+  const up = { href: '/', title: t`Home` }
   const staticClient = graphqlSsrClient(context)
   const conf = client.query({ query: StoreConfigDocument })
   const layout = staticClient.query({
@@ -85,7 +86,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   return {
     props: {
       ...(await layout).data,
-      up: { href: '/', title: t`Home` },
+      up,
       apolloState: await conf.then(() => client.cache.extract()),
     },
     revalidate: revalidate(),

--- a/examples/magento-graphcms/pages/[...url].tsx
+++ b/examples/magento-graphcms/pages/[...url].tsx
@@ -191,6 +191,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (!url || !query) return { notFound: true, revalidate: revalidate() }
 
   const client = graphqlSharedClient(context)
+  const homeUp = { href: '/', title: t`Home` }
   const conf = client.query({ query: StoreConfigDocument })
   const filterTypes = getFilterTypes(client)
 
@@ -259,7 +260,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   const up =
     category_url_path && category_name
       ? { href: `/${category_url_path}`, title: category_name }
-      : { href: '/', title: t`Home` }
+      : homeUp
 
   await waitForSiblings
   const result = {

--- a/examples/magento-graphcms/pages/account/addresses/add.tsx
+++ b/examples/magento-graphcms/pages/account/addresses/add.tsx
@@ -64,13 +64,14 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account', title: t`Account` }
   const conf = client.query({ query: StoreConfigDocument })
 
   return {
     props: {
       apolloState: await conf.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account', title: t`Account` },
+      up,
     },
   }
 }

--- a/examples/magento-graphcms/pages/account/addresses/edit.tsx
+++ b/examples/magento-graphcms/pages/account/addresses/edit.tsx
@@ -79,13 +79,14 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account/addresses', title: t`Addresses` }
   const conf = client.query({ query: StoreConfigDocument })
 
   return {
     props: {
       apolloState: await conf.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account/addresses', title: t`Addresses` },
+      up,
     },
   }
 }

--- a/examples/magento-graphcms/pages/account/addresses/index.tsx
+++ b/examples/magento-graphcms/pages/account/addresses/index.tsx
@@ -64,6 +64,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account', title: t`Account` }
   const staticClient = graphqlSsrClient(context)
   const conf = client.query({ query: StoreConfigDocument })
 
@@ -76,7 +77,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
       ...(await countryRegions).data,
       apolloState: await conf.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account', title: t`Account` },
+      up,
     },
   }
 }

--- a/examples/magento-graphcms/pages/account/authentication/index.tsx
+++ b/examples/magento-graphcms/pages/account/authentication/index.tsx
@@ -68,13 +68,14 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account', title: t`Account` }
   const conf = client.query({ query: StoreConfigDocument })
 
   return {
     props: {
       apolloState: await conf.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account', title: t`Account` },
+      up,
     },
   }
 }

--- a/examples/magento-graphcms/pages/account/contact/index.tsx
+++ b/examples/magento-graphcms/pages/account/contact/index.tsx
@@ -64,13 +64,14 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account', title: t`Account` }
   const conf = client.query({ query: StoreConfigDocument })
 
   return {
     props: {
       apolloState: await conf.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account', title: t`Account` },
+      up,
     },
   }
 }

--- a/examples/magento-graphcms/pages/account/forgot-password.tsx
+++ b/examples/magento-graphcms/pages/account/forgot-password.tsx
@@ -48,13 +48,14 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account/signin', title: t`Sign in` }
   const conf = client.query({ query: StoreConfigDocument })
 
   return {
     props: {
       apolloState: await conf.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account/signin', title: t`Sign in` },
+      up,
     },
   }
 }

--- a/examples/magento-graphcms/pages/account/index.tsx
+++ b/examples/magento-graphcms/pages/account/index.tsx
@@ -155,6 +155,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
 
   const staticClient = graphqlSsrClient(context)
   const client = graphqlSharedClient(context)
+  const up = { href: '/', title: t`Home` }
   const conf = client.query({ query: StoreConfigDocument })
   const layout = staticClient.query({
     query: LayoutDocument,
@@ -164,7 +165,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   return {
     props: {
       ...(await layout).data,
-      up: { href: '/', title: t`Home` },
+      up,
       apolloState: await conf.then(() => client.cache.extract()),
     },
     revalidate: revalidate(),

--- a/examples/magento-graphcms/pages/account/name/index.tsx
+++ b/examples/magento-graphcms/pages/account/name/index.tsx
@@ -77,6 +77,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account', title: t`Account` }
   const conf = client.query({ query: StoreConfigDocument })
 
   if (magentoVersion >= 247) await preloadAttributesForm(client, 'customer_account_edit')
@@ -85,7 +86,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
     props: {
       apolloState: await conf.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account', title: t`Account` },
+      up,
     },
   }
 }

--- a/examples/magento-graphcms/pages/account/orders/credit-memo.tsx
+++ b/examples/magento-graphcms/pages/account/orders/credit-memo.tsx
@@ -99,6 +99,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account/orders', title: t`Orders` }
   const staticClient = graphqlSsrClient(context)
   const config = client.query({ query: StoreConfigDocument })
 
@@ -111,7 +112,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
       ...(await countryRegions).data,
       apolloState: await config.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account/orders', title: t`Orders` },
+      up,
     },
   }
 }

--- a/examples/magento-graphcms/pages/account/orders/index.tsx
+++ b/examples/magento-graphcms/pages/account/orders/index.tsx
@@ -85,13 +85,14 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account', title: t`Account` }
   const conf = client.query({ query: StoreConfigDocument })
 
   return {
     props: {
       apolloState: await conf.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account', title: t`Account` },
+      up,
     },
   }
 }

--- a/examples/magento-graphcms/pages/account/orders/invoice.tsx
+++ b/examples/magento-graphcms/pages/account/orders/invoice.tsx
@@ -96,6 +96,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account/orders', title: t`Orders` }
   const staticClient = graphqlSsrClient(context)
   const config = client.query({ query: StoreConfigDocument })
 
@@ -108,7 +109,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
       ...(await countryRegions).data,
       apolloState: await config.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account/orders', title: t`Orders` },
+      up,
     },
   }
 }

--- a/examples/magento-graphcms/pages/account/orders/shipment.tsx
+++ b/examples/magento-graphcms/pages/account/orders/shipment.tsx
@@ -96,6 +96,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account/orders', title: t`Orders` }
   const staticClient = graphqlSsrClient(context)
   const config = client.query({ query: StoreConfigDocument })
 
@@ -108,7 +109,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
       ...(await countryRegions).data,
       apolloState: await config.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account/orders', title: t`Orders` },
+      up,
     },
   }
 }

--- a/examples/magento-graphcms/pages/account/orders/view.tsx
+++ b/examples/magento-graphcms/pages/account/orders/view.tsx
@@ -95,6 +95,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account/orders', title: t`Orders` }
   const staticClient = graphqlSsrClient(context)
   const config = client.query({ query: StoreConfigDocument })
 
@@ -107,7 +108,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
       ...(await countryRegions).data,
       apolloState: await config.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account/orders', title: t`Orders` },
+      up,
     },
   }
 }

--- a/examples/magento-graphcms/pages/account/reviews/index.tsx
+++ b/examples/magento-graphcms/pages/account/reviews/index.tsx
@@ -78,12 +78,13 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account', title: t`Account` }
   const conf = client.query({ query: StoreConfigDocument })
 
   return {
     props: {
       apolloState: await conf.then(() => client.cache.extract()),
-      up: { href: '/account', title: t`Account` },
+      up,
     },
   }
 }

--- a/examples/magento-graphcms/pages/blog/[...url].tsx
+++ b/examples/magento-graphcms/pages/blog/[...url].tsx
@@ -105,6 +105,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   const urlKey = params?.url.join('/') ?? ''
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/blog', title: t`Blog` }
   const staticClient = graphqlSsrClient(context)
   const limit = 4
   const conf = client.query({ query: StoreConfigDocument })
@@ -131,7 +132,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
       ...pageData,
       ...blogPostsData,
       ...(await layout).data,
-      up: { href: '/blog', title: t`Blog` },
+      up,
       apolloState: await conf.then(() => client.cache.extract()),
     },
     revalidate: revalidate(),

--- a/examples/magento-graphcms/pages/blog/tagged/[url].tsx
+++ b/examples/magento-graphcms/pages/blog/tagged/[url].tsx
@@ -82,6 +82,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   const { locale, params } = context
   const urlKey = params?.url ?? '??'
   const client = graphqlSharedClient(context)
+  const up = { href: '/blog', title: t`Blog` }
   const staticClient = graphqlSsrClient(context)
   const limit = 99
   const conf = client.query({ query: StoreConfigDocument })
@@ -106,7 +107,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
       ...pageData.data,
       ...posts.data,
       ...(await layout).data,
-      up: { href: '/blog', title: t`Blog` },
+      up,
       apolloState: await conf.then(() => client.cache.extract()),
     },
     revalidate: revalidate(),

--- a/examples/magento-graphcms/pages/checkout/customer/addresses/edit.tsx
+++ b/examples/magento-graphcms/pages/checkout/customer/addresses/edit.tsx
@@ -95,13 +95,14 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCartDisabled(context.locale) || getCustomerAccountIsDisabled(context.locale))
     return { notFound: true }
   const client = graphqlSharedClient(context)
+  const up = { href: '/checkout', title: t`Shipping` }
   const conf = client.query({ query: StoreConfigDocument })
 
   return {
     props: {
       apolloState: await conf.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/checkout', title: t`Shipping` },
+      up,
     },
   }
 }

--- a/examples/magento-graphcms/pages/checkout/index.tsx
+++ b/examples/magento-graphcms/pages/checkout/index.tsx
@@ -154,6 +154,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCheckoutIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/cart', title: t`Cart` }
   const conf = client.query({ query: StoreConfigDocument })
   const staticClient = graphqlSsrClient(context)
 
@@ -165,7 +166,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   return {
     props: {
       ...(await layout).data,
-      up: { href: '/cart', title: t`Cart` },
+      up,
       apolloState: await conf.then(() => client.cache.extract()),
     },
   }

--- a/examples/magento-graphcms/pages/checkout/payment.tsx
+++ b/examples/magento-graphcms/pages/checkout/payment.tsx
@@ -158,6 +158,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCheckoutIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/checkout', title: t`Shipping` }
   const staticClient = graphqlSsrClient(context)
 
   const conf = client.query({ query: StoreConfigDocument })
@@ -169,7 +170,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   return {
     props: {
       ...(await layout).data,
-      up: { href: '/checkout', title: t`Shipping` },
+      up,
       apolloState: await conf.then(() => client.cache.extract()),
     },
   }

--- a/examples/magento-graphcms/pages/checkout/success.tsx
+++ b/examples/magento-graphcms/pages/checkout/success.tsx
@@ -103,6 +103,7 @@ export default OrderSuccessPage
 export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCheckoutIsDisabled(context.locale)) return { notFound: true }
   const client = graphqlSharedClient(context)
+  const up = { href: '/', title: t`Home` }
   const staticClient = graphqlSsrClient(context)
   const conf = client.query({ query: StoreConfigDocument })
   const layout = staticClient.query({
@@ -112,7 +113,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   return {
     props: {
       ...(await layout).data,
-      up: { href: '/', title: t`Home` },
+      up,
       apolloState: await conf.then(() => client.cache.extract()),
     },
   }

--- a/examples/magento-graphcms/pages/customer/account/createPassword/index.tsx
+++ b/examples/magento-graphcms/pages/customer/account/createPassword/index.tsx
@@ -85,13 +85,14 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account/signin', title: t`Sign in` }
   const conf = client.query({ query: StoreConfigDocument })
 
   return {
     props: {
       apolloState: await conf.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account/signin', title: t`Sign in` },
+      up,
     },
   }
 }

--- a/examples/magento-graphcms/pages/p/[url].tsx
+++ b/examples/magento-graphcms/pages/p/[url].tsx
@@ -200,6 +200,7 @@ export const getStaticPaths: GetPageStaticPaths = async ({ locales = [] }) => {
 export const getStaticProps: GetPageStaticProps = async (context) => {
   const { locale, params } = context
   const client = graphqlSharedClient(context)
+  const homeUp = { href: '/', title: t`Home` }
   const staticClient = graphqlSsrClient(context)
 
   const urlKey = params?.url ?? '??'
@@ -226,7 +227,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   const up =
     category?.url_path && category?.name
       ? { href: `/${category.url_path}`, title: category.name }
-      : { href: '/', title: t`Home` }
+      : homeUp
   const usps = staticClient.query({ query: UspsDocument, fetchPolicy: cacheFirst(staticClient) })
 
   const result = {

--- a/examples/magento-graphcms/pages/search/[[...url]].tsx
+++ b/examples/magento-graphcms/pages/search/[[...url]].tsx
@@ -86,6 +86,7 @@ export const getServerSideProps: GetPageStaticProps = async (context) => {
   const search = searchShort.length >= 3 ? searchShort : ''
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/', title: t`Home` }
   const conf = client.query({ query: StoreConfigDocument })
   const filterTypes = getFilterTypes(client, true)
 
@@ -125,7 +126,7 @@ export const getServerSideProps: GetPageStaticProps = async (context) => {
       ...(await layout)?.data,
       filterTypes: await filterTypes,
       params: productListParams,
-      up: { href: '/', title: t`Home` },
+      up,
       apolloState: await conf.then(() => client.cache.extract()),
     },
   }

--- a/examples/magento-graphcms/pages/service/[[...url]].tsx
+++ b/examples/magento-graphcms/pages/service/[[...url]].tsx
@@ -90,6 +90,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   const { locale, params } = context
   const url = params?.url ? `service/${params?.url.join('/')}` : 'service'
   const client = graphqlSharedClient(context)
+  const up = url === 'service' ? null : { href: '/service', title: t`Customer Service` }
   const staticClient = graphqlSsrClient(context)
   const conf = client.query({ query: StoreConfigDocument })
   const page = hygraphPageContent(staticClient, url)
@@ -100,13 +101,11 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
 
   if (!(await page).data.pages?.[0]) return redirectOrNotFound(staticClient, conf, { url }, locale)
 
-  const isRoot = url === 'service'
-
   return {
     props: {
       ...(await page).data,
       ...(await layout).data,
-      up: isRoot ? null : { href: '/service', title: t`Customer Service` },
+      up,
       apolloState: await conf.then(() => client.cache.extract()),
     },
     revalidate: revalidate(),

--- a/examples/magento-graphcms/pages/service/contact-us.tsx
+++ b/examples/magento-graphcms/pages/service/contact-us.tsx
@@ -64,6 +64,7 @@ export default ContactUs
 export const getStaticProps: GetPageStaticProps = async (context) => {
   const url = 'service/contact-us'
   const client = graphqlSharedClient(context)
+  const up = { href: '/service', title: t`Customer Service` }
   const staticClient = graphqlSsrClient(context)
   const conf = client.query({ query: StoreConfigDocument })
   const page = hygraphPageContent(staticClient, url)
@@ -79,7 +80,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
     props: {
       ...(await page).data,
       ...(await layout).data,
-      up: { href: '/service', title: t`Customer Service` },
+      up,
       apolloState: await conf.then(() => client.cache.extract()),
     },
     revalidate: revalidate(),

--- a/examples/magento-graphcms/pages/service/newsletter.tsx
+++ b/examples/magento-graphcms/pages/service/newsletter.tsx
@@ -68,6 +68,7 @@ export default NewsletterSubscribe
 export const getStaticProps: GetPageStaticProps = async (context) => {
   const url = 'service/newsletter'
   const client = graphqlSharedClient(context)
+  const up = { href: '/service', title: t`Customer Service` }
   const staticClient = graphqlSsrClient(context)
   const conf = client.query({ query: StoreConfigDocument })
   const page = hygraphPageContent(staticClient, url)
@@ -82,7 +83,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
     props: {
       ...(await page).data,
       ...(await layout).data,
-      up: { href: '/service', title: t`Customer Service` },
+      up,
       apolloState: await conf.then(() => client.cache.extract()),
     },
     revalidate: revalidate(),

--- a/examples/magento-open-source/pages/404.tsx
+++ b/examples/magento-open-source/pages/404.tsx
@@ -55,6 +55,7 @@ export default RouteNotFoundPage
 
 export const getStaticProps: GetPageStaticProps = async (context) => {
   const client = graphqlSharedClient(context)
+  const up = { href: '/', title: t`Home` }
   const staticClient = graphqlSsrClient(context)
   const conf = client.query({ query: StoreConfigDocument })
   const layout = staticClient.query({
@@ -70,7 +71,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
     props: {
       ...(await layout).data,
       cmsPage: cmsPage ?? null,
-      up: { href: '/', title: t`Home` },
+      up,
       apolloState: await conf.then(() => client.cache.extract()),
     },
     revalidate: revalidate(),

--- a/examples/magento-open-source/pages/[...url].tsx
+++ b/examples/magento-open-source/pages/[...url].tsx
@@ -155,6 +155,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (!url || !query) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const homeUp = { href: '/', title: t`Home` }
   const conf = client.query({ query: StoreConfigDocument })
   const filterTypes = getFilterTypes(client)
 
@@ -221,7 +222,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   const up =
     category_url_path && category_name
       ? { href: `/${category_url_path}`, title: category_name }
-      : { href: '/', title: t`Home` }
+      : homeUp
 
   await waitForSiblings
   const result = {

--- a/examples/magento-open-source/pages/account/addresses/add.tsx
+++ b/examples/magento-open-source/pages/account/addresses/add.tsx
@@ -65,13 +65,14 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account', title: t`Account` }
   const conf = client.query({ query: StoreConfigDocument })
 
   return {
     props: {
       apolloState: await conf.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account', title: t`Account` },
+      up,
     },
   }
 }

--- a/examples/magento-open-source/pages/account/addresses/edit.tsx
+++ b/examples/magento-open-source/pages/account/addresses/edit.tsx
@@ -80,13 +80,14 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account/addresses', title: t`Addresses` }
   const conf = client.query({ query: StoreConfigDocument })
 
   return {
     props: {
       apolloState: await conf.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account/addresses', title: t`Addresses` },
+      up,
     },
   }
 }

--- a/examples/magento-open-source/pages/account/addresses/index.tsx
+++ b/examples/magento-open-source/pages/account/addresses/index.tsx
@@ -61,6 +61,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account', title: t`Account` }
   const staticClient = graphqlSsrClient(context)
   const conf = client.query({ query: StoreConfigDocument })
 
@@ -73,7 +74,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
       ...(await countryRegions).data,
       apolloState: await conf.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account', title: t`Account` },
+      up,
     },
   }
 }

--- a/examples/magento-open-source/pages/account/authentication/index.tsx
+++ b/examples/magento-open-source/pages/account/authentication/index.tsx
@@ -69,13 +69,14 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account', title: t`Account` }
   const conf = client.query({ query: StoreConfigDocument })
 
   return {
     props: {
       apolloState: await conf.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account', title: t`Account` },
+      up,
     },
   }
 }

--- a/examples/magento-open-source/pages/account/contact/index.tsx
+++ b/examples/magento-open-source/pages/account/contact/index.tsx
@@ -65,13 +65,14 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account', title: t`Account` }
   const conf = client.query({ query: StoreConfigDocument })
 
   return {
     props: {
       apolloState: await conf.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account', title: t`Account` },
+      up,
     },
   }
 }

--- a/examples/magento-open-source/pages/account/forgot-password.tsx
+++ b/examples/magento-open-source/pages/account/forgot-password.tsx
@@ -50,13 +50,14 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account/signin', title: t`Sign in` }
   const conf = client.query({ query: StoreConfigDocument })
 
   return {
     props: {
       apolloState: await conf.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account/signin', title: t`Sign in` },
+      up,
     },
   }
 }

--- a/examples/magento-open-source/pages/account/index.tsx
+++ b/examples/magento-open-source/pages/account/index.tsx
@@ -156,6 +156,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
 
   const staticClient = graphqlSsrClient(context)
   const client = graphqlSharedClient(context)
+  const up = { href: '/', title: t`Home` }
   const conf = client.query({ query: StoreConfigDocument })
   const layout = staticClient.query({
     query: LayoutDocument,
@@ -165,7 +166,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   return {
     props: {
       ...(await layout).data,
-      up: { href: '/', title: t`Home` },
+      up,
       apolloState: await conf.then(() => client.cache.extract()),
     },
     revalidate: revalidate(),

--- a/examples/magento-open-source/pages/account/name/index.tsx
+++ b/examples/magento-open-source/pages/account/name/index.tsx
@@ -73,6 +73,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account', title: t`Account` }
   const conf = client.query({ query: StoreConfigDocument })
 
   if (magentoVersion >= 247) await preloadAttributesForm(client, 'customer_account_edit')
@@ -81,7 +82,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
     props: {
       apolloState: await conf.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account', title: t`Account` },
+      up,
     },
   }
 }

--- a/examples/magento-open-source/pages/account/orders/credit-memo.tsx
+++ b/examples/magento-open-source/pages/account/orders/credit-memo.tsx
@@ -99,6 +99,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account/orders', title: t`Orders` }
   const staticClient = graphqlSsrClient(context)
   const config = client.query({ query: StoreConfigDocument })
 
@@ -111,7 +112,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
       ...(await countryRegions).data,
       apolloState: await config.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account/orders', title: t`Orders` },
+      up,
     },
   }
 }

--- a/examples/magento-open-source/pages/account/orders/index.tsx
+++ b/examples/magento-open-source/pages/account/orders/index.tsx
@@ -86,13 +86,14 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account', title: t`Account` }
   const conf = client.query({ query: StoreConfigDocument })
 
   return {
     props: {
       apolloState: await conf.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account', title: t`Account` },
+      up,
     },
   }
 }

--- a/examples/magento-open-source/pages/account/orders/invoice.tsx
+++ b/examples/magento-open-source/pages/account/orders/invoice.tsx
@@ -96,6 +96,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account/orders', title: t`Orders` }
   const staticClient = graphqlSsrClient(context)
   const config = client.query({ query: StoreConfigDocument })
 
@@ -108,7 +109,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
       ...(await countryRegions).data,
       apolloState: await config.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account/orders', title: t`Orders` },
+      up,
     },
   }
 }

--- a/examples/magento-open-source/pages/account/orders/shipment.tsx
+++ b/examples/magento-open-source/pages/account/orders/shipment.tsx
@@ -96,6 +96,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account/orders', title: t`Orders` }
   const staticClient = graphqlSsrClient(context)
   const config = client.query({ query: StoreConfigDocument })
 
@@ -108,7 +109,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
       ...(await countryRegions).data,
       apolloState: await config.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account/orders', title: t`Orders` },
+      up,
     },
   }
 }

--- a/examples/magento-open-source/pages/account/orders/view.tsx
+++ b/examples/magento-open-source/pages/account/orders/view.tsx
@@ -96,6 +96,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account/orders', title: t`Orders` }
   const staticClient = graphqlSsrClient(context)
   const config = client.query({ query: StoreConfigDocument })
 
@@ -108,7 +109,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
       ...(await countryRegions).data,
       apolloState: await config.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account/orders', title: t`Orders` },
+      up,
     },
   }
 }

--- a/examples/magento-open-source/pages/account/reviews/index.tsx
+++ b/examples/magento-open-source/pages/account/reviews/index.tsx
@@ -79,12 +79,13 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account', title: t`Account` }
   const conf = client.query({ query: StoreConfigDocument })
 
   return {
     props: {
       apolloState: await conf.then(() => client.cache.extract()),
-      up: { href: '/account', title: t`Account` },
+      up,
     },
   }
 }

--- a/examples/magento-open-source/pages/checkout/customer/addresses/edit.tsx
+++ b/examples/magento-open-source/pages/checkout/customer/addresses/edit.tsx
@@ -96,13 +96,14 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCartDisabled(context.locale) || getCustomerAccountIsDisabled(context.locale))
     return { notFound: true }
   const client = graphqlSharedClient(context)
+  const up = { href: '/checkout', title: t`Shipping` }
   const conf = client.query({ query: StoreConfigDocument })
 
   return {
     props: {
       apolloState: await conf.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/checkout', title: t`Shipping` },
+      up,
     },
   }
 }

--- a/examples/magento-open-source/pages/checkout/index.tsx
+++ b/examples/magento-open-source/pages/checkout/index.tsx
@@ -155,6 +155,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCheckoutIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/cart', title: t`Cart` }
   const conf = client.query({ query: StoreConfigDocument })
   const staticClient = graphqlSsrClient(context)
 
@@ -166,7 +167,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   return {
     props: {
       ...(await layout).data,
-      up: { href: '/cart', title: t`Cart` },
+      up,
       apolloState: await conf.then(() => client.cache.extract()),
     },
   }

--- a/examples/magento-open-source/pages/checkout/payment.tsx
+++ b/examples/magento-open-source/pages/checkout/payment.tsx
@@ -158,6 +158,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCheckoutIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/checkout', title: t`Shipping` }
   const staticClient = graphqlSsrClient(context)
 
   const conf = client.query({ query: StoreConfigDocument })
@@ -169,7 +170,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   return {
     props: {
       ...(await layout).data,
-      up: { href: '/checkout', title: t`Shipping` },
+      up,
       apolloState: await conf.then(() => client.cache.extract()),
     },
   }

--- a/examples/magento-open-source/pages/checkout/success.tsx
+++ b/examples/magento-open-source/pages/checkout/success.tsx
@@ -99,6 +99,7 @@ export default OrderSuccessPage
 export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCheckoutIsDisabled(context.locale)) return { notFound: true }
   const client = graphqlSharedClient(context)
+  const up = { href: '/', title: t`Home` }
   const staticClient = graphqlSsrClient(context)
   const conf = client.query({ query: StoreConfigDocument })
   const layout = staticClient.query({
@@ -108,7 +109,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   return {
     props: {
       ...(await layout).data,
-      up: { href: '/', title: t`Home` },
+      up,
       apolloState: await conf.then(() => client.cache.extract()),
     },
   }

--- a/examples/magento-open-source/pages/customer/account/createPassword.tsx
+++ b/examples/magento-open-source/pages/customer/account/createPassword.tsx
@@ -83,13 +83,14 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account/signin', title: t`Sign in` }
   const conf = client.query({ query: StoreConfigDocument })
 
   return {
     props: {
       apolloState: await conf.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account/signin', title: t`Sign in` },
+      up,
     },
   }
 }

--- a/examples/magento-open-source/pages/p/[url].tsx
+++ b/examples/magento-open-source/pages/p/[url].tsx
@@ -222,6 +222,7 @@ export const getStaticPaths: GetPageStaticPaths = async ({ locales = [] }) => {
 export const getStaticProps: GetPageStaticProps = async (context) => {
   const { locale, params } = context
   const client = graphqlSharedClient(context)
+  const homeUp = { href: '/', title: t`Home` }
   const staticClient = graphqlSsrClient(context)
 
   const urlKey = params?.url ?? '??'
@@ -247,7 +248,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   const up =
     category?.url_path && category?.name
       ? { href: `/${category.url_path}`, title: category.name }
-      : { href: '/', title: t`Home` }
+      : homeUp
 
   const result = {
     props: {

--- a/examples/magento-open-source/pages/search/[[...url]].tsx
+++ b/examples/magento-open-source/pages/search/[[...url]].tsx
@@ -89,6 +89,7 @@ export const getServerSideProps: GetPageStaticProps = async (context) => {
   const search = searchShort.length >= 3 ? searchShort : ''
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/', title: t`Home` }
   const conf = client.query({ query: StoreConfigDocument })
   const filterTypes = getFilterTypes(client, true)
 
@@ -137,7 +138,7 @@ export const getServerSideProps: GetPageStaticProps = async (context) => {
       ...(await layout)?.data,
       filterTypes: await filterTypes,
       params: productListParams,
-      up: { href: '/', title: t`Home` },
+      up,
       apolloState: await conf.then(() => client.cache.extract()),
     },
   }

--- a/examples/magento-open-source/pages/service/contact-us.tsx
+++ b/examples/magento-open-source/pages/service/contact-us.tsx
@@ -50,6 +50,7 @@ export default ContactUs
 
 export const getStaticProps: GetPageStaticProps = async (context) => {
   const client = graphqlSharedClient(context)
+  const up = { href: '/service', title: t`Customer Service` }
   const staticClient = graphqlSsrClient(context)
   const conf = client.query({ query: StoreConfigDocument })
   const layout = staticClient.query({
@@ -62,7 +63,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   return {
     props: {
       ...(await layout).data,
-      up: { href: '/service', title: t`Customer Service` },
+      up,
       apolloState: await conf.then(() => client.cache.extract()),
     },
     revalidate: revalidate(),

--- a/examples/magento-open-source/pages/service/newsletter.tsx
+++ b/examples/magento-open-source/pages/service/newsletter.tsx
@@ -52,6 +52,7 @@ export default NewsletterSubscribe
 
 export const getStaticProps: GetPageStaticProps = async (context) => {
   const client = graphqlSharedClient(context)
+  const up = { href: '/service', title: t`Customer Service` }
   const staticClient = graphqlSsrClient(context)
   const conf = client.query({ query: StoreConfigDocument })
   const layout = staticClient.query({
@@ -62,7 +63,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   return {
     props: {
       ...(await layout).data,
-      up: { href: '/service', title: t`Customer Service` },
+      up,
       apolloState: await conf.then(() => client.cache.extract()),
     },
     revalidate: revalidate(),

--- a/examples/magento-storyblok/pages/404.tsx
+++ b/examples/magento-storyblok/pages/404.tsx
@@ -49,6 +49,7 @@ export default RouteNotFoundPage
 
 export const getStaticProps: GetPageStaticProps = async (context) => {
   const client = graphqlSharedClient(context)
+  const up = { href: '/', title: t`Home` }
   const staticClient = graphqlSsrClient(context)
   const conf = client.query({ query: StoreConfigDocument })
   const layout = staticClient.query({
@@ -61,7 +62,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
     props: {
       ...(await layout).data,
       globalConfig: (await globalConfig)?.content ?? null,
-      up: { href: '/', title: t`Home` },
+      up,
       apolloState: await conf.then(() => client.cache.extract()),
     },
     revalidate: revalidate(),

--- a/examples/magento-storyblok/pages/[...url].tsx
+++ b/examples/magento-storyblok/pages/[...url].tsx
@@ -179,6 +179,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (!url || !query) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const homeUp = { href: '/', title: t`Home` }
   const conf = client.query({ query: StoreConfigDocument })
   const filterTypes = getFilterTypes(client)
 
@@ -249,7 +250,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   const up =
     category_url_path && category_name
       ? { href: `/${category_url_path}`, title: category_name }
-      : { href: '/', title: t`Home` }
+      : homeUp
 
   await waitForSiblings
   const result = {

--- a/examples/magento-storyblok/pages/account/addresses/add.tsx
+++ b/examples/magento-storyblok/pages/account/addresses/add.tsx
@@ -65,13 +65,14 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account', title: t`Account` }
   const conf = client.query({ query: StoreConfigDocument })
 
   return {
     props: {
       apolloState: await conf.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account', title: t`Account` },
+      up,
     },
   }
 }

--- a/examples/magento-storyblok/pages/account/addresses/edit.tsx
+++ b/examples/magento-storyblok/pages/account/addresses/edit.tsx
@@ -80,13 +80,14 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account/addresses', title: t`Addresses` }
   const conf = client.query({ query: StoreConfigDocument })
 
   return {
     props: {
       apolloState: await conf.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account/addresses', title: t`Addresses` },
+      up,
     },
   }
 }

--- a/examples/magento-storyblok/pages/account/addresses/index.tsx
+++ b/examples/magento-storyblok/pages/account/addresses/index.tsx
@@ -61,6 +61,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account', title: t`Account` }
   const staticClient = graphqlSsrClient(context)
   const conf = client.query({ query: StoreConfigDocument })
 
@@ -73,7 +74,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
       ...(await countryRegions).data,
       apolloState: await conf.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account', title: t`Account` },
+      up,
     },
   }
 }

--- a/examples/magento-storyblok/pages/account/authentication/index.tsx
+++ b/examples/magento-storyblok/pages/account/authentication/index.tsx
@@ -69,13 +69,14 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account', title: t`Account` }
   const conf = client.query({ query: StoreConfigDocument })
 
   return {
     props: {
       apolloState: await conf.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account', title: t`Account` },
+      up,
     },
   }
 }

--- a/examples/magento-storyblok/pages/account/contact/index.tsx
+++ b/examples/magento-storyblok/pages/account/contact/index.tsx
@@ -65,13 +65,14 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account', title: t`Account` }
   const conf = client.query({ query: StoreConfigDocument })
 
   return {
     props: {
       apolloState: await conf.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account', title: t`Account` },
+      up,
     },
   }
 }

--- a/examples/magento-storyblok/pages/account/forgot-password.tsx
+++ b/examples/magento-storyblok/pages/account/forgot-password.tsx
@@ -50,13 +50,14 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account/signin', title: t`Sign in` }
   const conf = client.query({ query: StoreConfigDocument })
 
   return {
     props: {
       apolloState: await conf.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account/signin', title: t`Sign in` },
+      up,
     },
   }
 }

--- a/examples/magento-storyblok/pages/account/index.tsx
+++ b/examples/magento-storyblok/pages/account/index.tsx
@@ -157,6 +157,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
 
   const staticClient = graphqlSsrClient(context)
   const client = graphqlSharedClient(context)
+  const up = { href: '/', title: t`Home` }
   const conf = client.query({ query: StoreConfigDocument })
   const layout = staticClient.query({
     query: LayoutDocument,
@@ -168,7 +169,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
     props: {
       ...(await layout).data,
       globalConfig: (await globalConfig)?.content ?? null,
-      up: { href: '/', title: t`Home` },
+      up,
       apolloState: await conf.then(() => client.cache.extract()),
     },
     revalidate: revalidate(),

--- a/examples/magento-storyblok/pages/account/name/index.tsx
+++ b/examples/magento-storyblok/pages/account/name/index.tsx
@@ -73,6 +73,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account', title: t`Account` }
   const conf = client.query({ query: StoreConfigDocument })
 
   if (magentoVersion >= 247) await preloadAttributesForm(client, 'customer_account_edit')
@@ -81,7 +82,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
     props: {
       apolloState: await conf.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account', title: t`Account` },
+      up,
     },
   }
 }

--- a/examples/magento-storyblok/pages/account/orders/credit-memo.tsx
+++ b/examples/magento-storyblok/pages/account/orders/credit-memo.tsx
@@ -99,6 +99,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account/orders', title: t`Orders` }
   const staticClient = graphqlSsrClient(context)
   const config = client.query({ query: StoreConfigDocument })
 
@@ -111,7 +112,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
       ...(await countryRegions).data,
       apolloState: await config.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account/orders', title: t`Orders` },
+      up,
     },
   }
 }

--- a/examples/magento-storyblok/pages/account/orders/index.tsx
+++ b/examples/magento-storyblok/pages/account/orders/index.tsx
@@ -86,13 +86,14 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account', title: t`Account` }
   const conf = client.query({ query: StoreConfigDocument })
 
   return {
     props: {
       apolloState: await conf.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account', title: t`Account` },
+      up,
     },
   }
 }

--- a/examples/magento-storyblok/pages/account/orders/invoice.tsx
+++ b/examples/magento-storyblok/pages/account/orders/invoice.tsx
@@ -96,6 +96,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account/orders', title: t`Orders` }
   const staticClient = graphqlSsrClient(context)
   const config = client.query({ query: StoreConfigDocument })
 
@@ -108,7 +109,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
       ...(await countryRegions).data,
       apolloState: await config.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account/orders', title: t`Orders` },
+      up,
     },
   }
 }

--- a/examples/magento-storyblok/pages/account/orders/shipment.tsx
+++ b/examples/magento-storyblok/pages/account/orders/shipment.tsx
@@ -96,6 +96,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account/orders', title: t`Orders` }
   const staticClient = graphqlSsrClient(context)
   const config = client.query({ query: StoreConfigDocument })
 
@@ -108,7 +109,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
       ...(await countryRegions).data,
       apolloState: await config.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account/orders', title: t`Orders` },
+      up,
     },
   }
 }

--- a/examples/magento-storyblok/pages/account/orders/view.tsx
+++ b/examples/magento-storyblok/pages/account/orders/view.tsx
@@ -96,6 +96,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account/orders', title: t`Orders` }
   const staticClient = graphqlSsrClient(context)
   const config = client.query({ query: StoreConfigDocument })
 
@@ -108,7 +109,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
       ...(await countryRegions).data,
       apolloState: await config.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account/orders', title: t`Orders` },
+      up,
     },
   }
 }

--- a/examples/magento-storyblok/pages/account/reviews/index.tsx
+++ b/examples/magento-storyblok/pages/account/reviews/index.tsx
@@ -79,12 +79,13 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account', title: t`Account` }
   const conf = client.query({ query: StoreConfigDocument })
 
   return {
     props: {
       apolloState: await conf.then(() => client.cache.extract()),
-      up: { href: '/account', title: t`Account` },
+      up,
     },
   }
 }

--- a/examples/magento-storyblok/pages/blog/[...url].tsx
+++ b/examples/magento-storyblok/pages/blog/[...url].tsx
@@ -133,6 +133,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   const slug = `blog/${params?.url?.join('/') ?? ''}`
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/blog', title: t`Blog` }
   const staticClient = graphqlSsrClient(context)
   const conf = client.query({ query: StoreConfigDocument })
   const layout = staticClient.query({
@@ -158,7 +159,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
       related: (await related).stories,
       ...(await layout).data,
       globalConfig: (await globalConfig)?.content ?? null,
-      up: { href: '/blog', title: t`Blog` },
+      up,
       apolloState: await conf.then(() => client.cache.extract()),
     },
     revalidate: revalidate(),

--- a/examples/magento-storyblok/pages/blog/tagged/[url].tsx
+++ b/examples/magento-storyblok/pages/blog/tagged/[url].tsx
@@ -92,6 +92,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (!tag) return { notFound: true, revalidate: revalidate() }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/blog', title: t`Blog` }
   const staticClient = graphqlSsrClient(context)
   const conf = client.query({ query: StoreConfigDocument })
   const layout = staticClient.query({
@@ -116,7 +117,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
       stories,
       ...(await layout).data,
       globalConfig: (await globalConfig)?.content ?? null,
-      up: { href: '/blog', title: t`Blog` },
+      up,
       apolloState: await conf.then(() => client.cache.extract()),
     },
     revalidate: revalidate(),

--- a/examples/magento-storyblok/pages/checkout/customer/addresses/edit.tsx
+++ b/examples/magento-storyblok/pages/checkout/customer/addresses/edit.tsx
@@ -96,13 +96,14 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCartDisabled(context.locale) || getCustomerAccountIsDisabled(context.locale))
     return { notFound: true }
   const client = graphqlSharedClient(context)
+  const up = { href: '/checkout', title: t`Shipping` }
   const conf = client.query({ query: StoreConfigDocument })
 
   return {
     props: {
       apolloState: await conf.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/checkout', title: t`Shipping` },
+      up,
     },
   }
 }

--- a/examples/magento-storyblok/pages/checkout/index.tsx
+++ b/examples/magento-storyblok/pages/checkout/index.tsx
@@ -156,6 +156,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCheckoutIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/cart', title: t`Cart` }
   const conf = client.query({ query: StoreConfigDocument })
   const staticClient = graphqlSsrClient(context)
 
@@ -169,7 +170,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
     props: {
       ...(await layout).data,
       globalConfig: (await globalConfig)?.content ?? null,
-      up: { href: '/cart', title: t`Cart` },
+      up,
       apolloState: await conf.then(() => client.cache.extract()),
     },
   }

--- a/examples/magento-storyblok/pages/checkout/payment.tsx
+++ b/examples/magento-storyblok/pages/checkout/payment.tsx
@@ -159,6 +159,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCheckoutIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/checkout', title: t`Shipping` }
   const staticClient = graphqlSsrClient(context)
 
   const conf = client.query({ query: StoreConfigDocument })
@@ -172,7 +173,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
     props: {
       ...(await layout).data,
       globalConfig: (await globalConfig)?.content ?? null,
-      up: { href: '/checkout', title: t`Shipping` },
+      up,
       apolloState: await conf.then(() => client.cache.extract()),
     },
   }

--- a/examples/magento-storyblok/pages/checkout/success.tsx
+++ b/examples/magento-storyblok/pages/checkout/success.tsx
@@ -100,6 +100,7 @@ export default OrderSuccessPage
 export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCheckoutIsDisabled(context.locale)) return { notFound: true }
   const client = graphqlSharedClient(context)
+  const up = { href: '/', title: t`Home` }
   const staticClient = graphqlSsrClient(context)
   const conf = client.query({ query: StoreConfigDocument })
   const layout = staticClient.query({
@@ -111,7 +112,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
     props: {
       ...(await layout).data,
       globalConfig: (await globalConfig)?.content ?? null,
-      up: { href: '/', title: t`Home` },
+      up,
       apolloState: await conf.then(() => client.cache.extract()),
     },
   }

--- a/examples/magento-storyblok/pages/customer/account/createPassword.tsx
+++ b/examples/magento-storyblok/pages/customer/account/createPassword.tsx
@@ -83,13 +83,14 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   if (getCustomerAccountIsDisabled(context.locale)) return { notFound: true }
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/account/signin', title: t`Sign in` }
   const conf = client.query({ query: StoreConfigDocument })
 
   return {
     props: {
       apolloState: await conf.then(() => client.cache.extract()),
       variantMd: 'bottom',
-      up: { href: '/account/signin', title: t`Sign in` },
+      up,
     },
   }
 }

--- a/examples/magento-storyblok/pages/p/[url].tsx
+++ b/examples/magento-storyblok/pages/p/[url].tsx
@@ -213,6 +213,7 @@ export const getStaticPaths: GetPageStaticPaths = async ({ locales = [] }) => {
 export const getStaticProps: GetPageStaticProps = async (context) => {
   const { locale, params } = context
   const client = graphqlSharedClient(context)
+  const homeUp = { href: '/', title: t`Home` }
   const staticClient = graphqlSsrClient(context)
 
   const urlKey = params?.url ?? '??'
@@ -241,7 +242,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   const up =
     category?.url_path && category?.name
       ? { href: `/${category.url_path}`, title: category.name }
-      : { href: '/', title: t`Home` }
+      : homeUp
 
   const result = {
     props: {

--- a/examples/magento-storyblok/pages/search/[[...url]].tsx
+++ b/examples/magento-storyblok/pages/search/[[...url]].tsx
@@ -90,6 +90,7 @@ export const getServerSideProps: GetPageStaticProps = async (context) => {
   const search = searchShort.length >= 3 ? searchShort : ''
 
   const client = graphqlSharedClient(context)
+  const up = { href: '/', title: t`Home` }
   const conf = client.query({ query: StoreConfigDocument })
   const filterTypes = getFilterTypes(client, true)
 
@@ -140,7 +141,7 @@ export const getServerSideProps: GetPageStaticProps = async (context) => {
       globalConfig: (await globalConfig)?.content ?? null,
       filterTypes: await filterTypes,
       params: productListParams,
-      up: { href: '/', title: t`Home` },
+      up,
       apolloState: await conf.then(() => client.cache.extract()),
     },
   }

--- a/examples/magento-storyblok/pages/service/[[...url]].tsx
+++ b/examples/magento-storyblok/pages/service/[[...url]].tsx
@@ -71,6 +71,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   const isRoot = slug === 'service'
 
   const client = graphqlSharedClient(context)
+  const up = isRoot ? null : { href: '/service', title: t`Customer Service` }
   const staticClient = graphqlSsrClient(context)
   const conf = client.query({ query: StoreConfigDocument })
   const layout = staticClient.query({
@@ -87,7 +88,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
     props: {
       story,
       ...(await layout).data,
-      up: isRoot ? null : { href: '/service', title: t`Customer Service` },
+      up,
       apolloState: await conf.then(() => client.cache.extract()),
     },
     revalidate: revalidate(),

--- a/examples/magento-storyblok/pages/service/contact-us.tsx
+++ b/examples/magento-storyblok/pages/service/contact-us.tsx
@@ -57,6 +57,7 @@ export default ContactUs
 
 export const getStaticProps: GetPageStaticProps = async (context) => {
   const client = graphqlSharedClient(context)
+  const up = { href: '/service', title: t`Customer Service` }
   const staticClient = graphqlSsrClient(context)
   const conf = client.query({ query: StoreConfigDocument })
   const layout = staticClient.query({
@@ -72,7 +73,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
     props: {
       story: (await storyPage).data?.story ?? null,
       ...(await layout).data,
-      up: { href: '/service', title: t`Customer Service` },
+      up,
       apolloState: await conf.then(() => client.cache.extract()),
     },
     revalidate: revalidate(),

--- a/examples/magento-storyblok/pages/service/newsletter.tsx
+++ b/examples/magento-storyblok/pages/service/newsletter.tsx
@@ -61,6 +61,7 @@ export default NewsletterSubscribe
 
 export const getStaticProps: GetPageStaticProps = async (context) => {
   const client = graphqlSharedClient(context)
+  const up = { href: '/service', title: t`Customer Service` }
   const staticClient = graphqlSsrClient(context)
   const conf = client.query({ query: StoreConfigDocument })
   const layout = staticClient.query({
@@ -74,7 +75,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
     props: {
       story: (await storyPage).data?.story ?? null,
       ...(await layout).data,
-      up: { href: '/service', title: t`Customer Service` },
+      up,
       apolloState: await conf.then(() => client.cache.extract()),
     },
     revalidate: revalidate(),

--- a/packages/demo-magento-graphcommerce/copy/pages/test/[[...url]].tsx
+++ b/packages/demo-magento-graphcommerce/copy/pages/test/[[...url]].tsx
@@ -65,6 +65,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   const url = (params?.url ?? ['index']).join('/') ?? ''
 
   const client = graphqlSharedClient(context)
+  const up = url !== 'index' ? { href: '/', title: t`Home` } : null
   const staticClient = graphqlSsrClient(context)
 
   const conf = client.query({ query: StoreConfigDocument })
@@ -76,7 +77,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   return {
     props: {
       url,
-      up: url !== 'index' ? { href: '/', title: t`Home` } : null,
+      up,
       ...(await layout).data,
       apolloState: await conf.then(() => client.cache.extract()),
     },

--- a/packages/demo-magento-graphcommerce/copy/pages/test/slider.tsx
+++ b/packages/demo-magento-graphcommerce/copy/pages/test/slider.tsx
@@ -88,6 +88,7 @@ export default TestSlider
 
 export const getStaticProps: GetPageStaticProps = async (context) => {
   const client = graphqlSharedClient(context)
+  const up = { href: '/', title: t`Home` }
   const staticClient = graphqlSsrClient(context)
 
   const conf = client.query({ query: StoreConfigDocument })
@@ -101,7 +102,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   return {
     props: {
       ...(await productList).data,
-      up: { href: '/', title: t`Home` },
+      up,
       apolloState: await conf.then(() => client.cache.extract()),
     },
   }

--- a/packages/demo-magento-graphcommerce/copy/pages/test/typography.tsx
+++ b/packages/demo-magento-graphcommerce/copy/pages/test/typography.tsx
@@ -198,6 +198,7 @@ export default TypographyOverview
 
 export const getStaticProps: GetPageStaticProps = async (context) => {
   const client = graphqlSharedClient(context)
+  const up = { href: '/', title: t`Home` }
   const staticClient = graphqlSsrClient(context)
 
   const conf = client.query({ query: StoreConfigDocument })
@@ -209,7 +210,7 @@ export const getStaticProps: GetPageStaticProps = async (context) => {
   return {
     props: {
       ...(await layout).data,
-      up: { href: '/', title: t`Home` },
+      up,
       apolloState: await conf.then(() => client.cache.extract()),
     },
   }


### PR DESCRIPTION
Bug: The `up` (back/breadcrumb) link title is a Lingui `t` macro string,
but it was constructed inline in the returned `props` object, after
`await`ing the layout/page/config GraphQL queries. Lingui translates
against a single global active-locale i18n instance, so a concurrent
static-generation request for a different locale could call
`i18n.activate()` during those awaits and cause the `t\`...\`` title to be
rendered in the wrong language for the page being generated.

Fix: Compute the `up` object (and its `t\`...\`` title) synchronously at
the top of every affected `getStaticProps`, before any `await` yields
control, so the translation is captured with the correct locale for the
current request. Applied uniformly across the magento-graphcms,
magento-open-source, and magento-storyblok example pages and the
demo-magento-graphcommerce copy pages.