### PR TITLE
fix(next-ui): don't render disabled pagination items as links

### DIFF
--- a/.changeset/pagination-disabled-no-link.md
+++ b/.changeset/pagination-disabled-no-link.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/next-ui': patch
+---
+
+Only render disabled pagination items as links when enabled. Disabled `PaginationItem`s no longer receive a `component`/`href`, preventing crawlers from following links to an infinite number of list pages and inflating the static page cache.

--- a/packages/next-ui/Pagination/PaginationExtended.tsx
+++ b/packages/next-ui/Pagination/PaginationExtended.tsx
@@ -84,8 +84,7 @@ export function PaginationExtended(props: PaginationExtendedProps) {
           renderItem ??
           ((item) => (
             <PaginationItem
-              component={NextLink}
-              href={paginationHref(item)}
+              {...(!item.disabled && { component: NextLink, href: paginationHref(item) })}
               slots={{ previous: Prev, next: Next }}
               {...item}
             />


### PR DESCRIPTION
Disabled PaginationItems were still given a `component`/`href`, turning them into anchors. Crawlers follow those links to an unbounded number of list pages, needlessly building up the static page cache.

Only pass `component`/`href` when the item is enabled; disabled items fall back to a plain button, so bots no longer have a link to crawl.