### PR TITLE
fix(graphql-mesh): disable Next bodyParser so multipart uploads survive the mesh

### DIFF
--- a/.changeset/mesh-multipart-bodyparser.md
+++ b/.changeset/mesh-multipart-bodyparser.md
@@ -1,0 +1,11 @@
+---
+'@graphcommerce/graphql-mesh': patch
+---
+
+Fix GraphQL multipart uploads (`Upload` scalar) through the Mesh. Next.js'
+pages-router bodyParser decodes multipart request bodies as UTF-8 text before
+Yoga can parse them, silently corrupting binary upload bytes (invalid UTF-8
+sequences become replacement characters and the part's mime type is lost). The
+`/api/graphql` route now sets `bodyParser: false` so Yoga receives the raw
+stream, and `createServer` throws a descriptive error when it receives a
+multipart request whose body was already consumed by the bodyParser.

--- a/examples/magento-graphcms/pages/api/graphql.ts
+++ b/examples/magento-graphcms/pages/api/graphql.ts
@@ -2,4 +2,6 @@ import { createServer } from '@graphcommerce/graphql-mesh'
 
 export default await createServer('/api/graphql')
 
-export const config = { api: { externalResolver: true } }
+// bodyParser must stay disabled: Yoga parses the request body itself, and Next's bodyParser
+// decodes multipart bodies as UTF-8 text, corrupting binary `Upload` variables.
+export const config = { api: { externalResolver: true, bodyParser: false } }

--- a/examples/magento-open-source/pages/api/graphql.ts
+++ b/examples/magento-open-source/pages/api/graphql.ts
@@ -2,4 +2,6 @@ import { createServer } from '@graphcommerce/graphql-mesh'
 
 export default await createServer('/api/graphql')
 
-export const config = { api: { externalResolver: true } }
+// bodyParser must stay disabled: Yoga parses the request body itself, and Next's bodyParser
+// decodes multipart bodies as UTF-8 text, corrupting binary `Upload` variables.
+export const config = { api: { externalResolver: true, bodyParser: false } }

--- a/examples/magento-storyblok/pages/api/graphql.ts
+++ b/examples/magento-storyblok/pages/api/graphql.ts
@@ -2,4 +2,6 @@ import { createServer } from '@graphcommerce/graphql-mesh'
 
 export default await createServer('/api/graphql')
 
-export const config = { api: { externalResolver: true } }
+// bodyParser must stay disabled: Yoga parses the request body itself, and Next's bodyParser
+// decodes multipart bodies as UTF-8 text, corrupting binary `Upload` variables.
+export const config = { api: { externalResolver: true, bodyParser: false } }

--- a/packages/graphql-mesh/api/createEnvelop.ts
+++ b/packages/graphql-mesh/api/createEnvelop.ts
@@ -8,6 +8,15 @@ export const createServer = async (endpoint: string) => {
 
   const handler = createBuiltMeshHTTPHandler()
   return async (req: NextApiRequest, res: NextApiResponse) => {
+    if (req.headers['content-type']?.startsWith('multipart/form-data') && req.body !== undefined) {
+      // Next's pages-router bodyParser has already consumed the request stream and decoded it as
+      // UTF-8 text, which corrupts binary `Upload` bytes (the multipart boundary survives, so the
+      // request would otherwise be forwarded with silently mangled file contents).
+      throw Error(
+        "Multipart GraphQL requests require Next.js' bodyParser to be disabled. Add `bodyParser: false` to the route config in pages/api/graphql.ts: export const config = { api: { externalResolver: true, bodyParser: false } }",
+      )
+    }
+
     res.setHeader('Access-Control-Allow-Origin', req.headers.origin || '*')
     const requestedHeaders = req.headers['access-control-request-headers']
     if (requestedHeaders) {


### PR DESCRIPTION
## The problem

GraphQL multipart uploads (`Upload` scalar per the [graphql-multipart-request-spec](https://github.com/jaydenseric/graphql-multipart-request-spec)) are corrupted when sent through `/api/graphql`. Next.js' pages-router bodyParser consumes the request stream and decodes it as UTF-8 **text** before Yoga can parse it. The multipart boundary is ASCII and survives, but binary file bytes are mangled: every invalid UTF-8 sequence becomes a U+FFFD replacement character (payload grows), and the part's mime type is lost. Because the request still parses as valid multipart, the corrupt bytes are forwarded upstream silently.

Reproduced with an echo mutation on a Magento upstream comparing sha256 of sent vs received bytes: a 70-byte PNG arrives as 92 bytes, `application/octet-stream`, sha256 equal to `Buffer.from(png.toString('utf8'), 'utf8')` — the exact lossy-UTF-8-round-trip signature.

This has historically been misattributed to `@graphql-tools/executor-http` re-encoding the outbound body. It doesn't — with the raw stream reaching Yoga, the whole pipeline (Yoga multipart parsing in, `executor-http` `createFormDataFromVariables` out) is byte-safe end to end, verified sha256-identical against a Magento upstream.

## The fix

- `examples/*/pages/api/graphql.ts`: add `bodyParser: false` to the route config so Yoga receives the raw stream. JSON POST and GET queries are unaffected (Yoga reads the stream itself, like on every non-Next server).
- `createServer` now throws a descriptive error pointing at the route config when it receives a multipart request whose body was already consumed, instead of forwarding corrupt bytes.

Existing projects pick this up by adding `bodyParser: false` to their own `pages/api/graphql.ts`; the `createServer` guard tells them exactly that if they forget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)