### PR TITLE
fix(ecommerce-ui): stop Preview Mode infinite reload in production

### DIFF
--- a/.changeset/fix-preview-mode-infinite-reload.md
+++ b/.changeset/fix-preview-mode-infinite-reload.md
@@ -1,0 +1,17 @@
+---
+'@graphcommerce/ecommerce-ui': patch
+---
+
+Fix Preview Mode causing an infinite reload loop in production
+
+When enabling Preview Mode in production the `secret` has to be typed (it is only
+pre-filled in development), which marks the field dirty and persists it to
+`sessionStorage` via `FormPersist`. On the next render `PreviewModeEnabled`
+restored that persisted `secret` with `setValue(…, { shouldDirty: true })`, which
+the all-fields `FormAutoSubmit` interpreted as a user change and submitted the
+`update` action — a `window.location` navigation to `/api/preview` that redirects
+back with a `307`, re-triggering the restore and reload endlessly.
+
+`FormAutoSubmit` now watches only `previewData` (the field the toolbar actually
+edits), and the preview `secret` is excluded from `FormPersist` so the token is no
+longer stored in the browser.

--- a/packages/ecommerce-ui/components/PreviewMode/PreviewModeDisabled.tsx
+++ b/packages/ecommerce-ui/components/PreviewMode/PreviewModeDisabled.tsx
@@ -50,7 +50,7 @@ export function PreviewModeDisabled() {
           <TextFieldElement control={form.control} name='secret' label='Secret' />
         </Box>
       </MessageSnackbar>
-      <FormPersist form={form} name='PreviewModePreviewData' />
+      <FormPersist form={form} name='PreviewModePreviewData' exclude={['secret']} />
     </FormProvider>
   )
 }

--- a/packages/ecommerce-ui/components/PreviewMode/PreviewModeEnabled.tsx
+++ b/packages/ecommerce-ui/components/PreviewMode/PreviewModeEnabled.tsx
@@ -91,8 +91,13 @@ export function PreviewModeEnabled() {
           <PreviewModeToolbar />
         </Box>
       </MessageSnackbar>
-      <FormPersist form={form} name='PreviewModePreviewData' />
-      <FormAutoSubmit control={form.control} submit={submit} />
+      {/* Exclude `secret` from persistence: it is only relevant to the `enable` action and storing
+          the preview token in the browser is a needless secret leak. */}
+      <FormPersist form={form} name='PreviewModePreviewData' exclude={['secret']} />
+      {/* Only auto-submit on `previewData` edits. Watching every field made the restore of a
+          persisted `secret` (via `setValue(shouldDirty)`) look like a user change, which fired the
+          `update` submit → 307 redirect → reload → restore → … infinite loop in production. */}
+      <FormAutoSubmit control={form.control} name={['previewData']} submit={submit} />
     </FormProvider>
   )
 }


### PR DESCRIPTION
## Problem

Opening **Preview Mode** (the `Alt`+`` ` `` toggle from `PreviewModeFramerNextPages`) in a **production** build causes an infinite reload loop.

## Root cause

1. In production the secret is **not** pre-filled — `PreviewModeDisabled` sets `const secret = process.env.NODE_ENV === 'development' ? … : ''`. The user has to *type* it, which marks the field dirty, so `FormPersist` writes it to `sessionStorage['PreviewModePreviewData']`.
2. After enabling, `PreviewModeEnabled` mounts and its `FormPersist` **restores** that persisted `secret` with `setValue(…, { shouldDirty: true, shouldValidate: true })`.
3. Its `FormAutoSubmit` watches **every** field, so the restored `secret` looks like a user edit → it submits the `update` action → `window.location = /api/preview?action=update…`.
4. The route replies `307` back to the same page → reload → step 2 → **infinite loop**.

In development the loop doesn't occur because the pre-filled secret is a *default value* (never dirty), so nothing is persisted and there is nothing to restore.

## Fix

- Scope `FormAutoSubmit` to `name={['previewData']}` — it should only react to actual preview-data edits (what the toolbar edits), not to the restored `secret`.
- Add `exclude={['secret']}` to both `FormPersist` instances so the preview token is no longer written to browser storage (also removes a needless secret leak).

Either change breaks the loop; together they also stop persisting the token.

## Notes

- The `PreviewModeToolbar` / `PreviewModeActions` are currently no-op (`return null`), so there are no editable `previewData` fields today; the auto-submit had nothing legitimate to submit and only ever fired on the restored secret.