### PR TITLE
feat(graphql): add terminatingLink prop to GraphQLProvider

### DIFF
--- a/.changeset/graphql-provider-terminating-link.md
+++ b/.changeset/graphql-provider-terminating-link.md
@@ -1,0 +1,7 @@
+---
+'@graphcommerce/graphql': minor
+---
+
+Add a `terminatingLink` prop to `GraphQLProvider` to override the terminating link at the tail of the Apollo link chain (by default the `HttpLink` to the Mesh backend).
+
+Because the terminating link runs after every context-setting link (customer auth token, store, cache-id, header links), this lets you route specific operations to a different transport while still inheriting all request headers. The motivating case is file uploads: `File`/`Blob` variables must be sent as a `multipart/form-data` request (e.g. via `apollo-upload-client`'s `UploadHttpLink`), which the default `HttpLink` cannot serialize. Previously such an upload link had to be prepended via `links`, where it terminated *before* the auth/header links could run — dropping the customer token from multipart requests, so a logged-in customer's cart mutations were rejected. Supplying the upload-aware split as `terminatingLink` keeps it at the tail, so uploads inherit the token like any other operation.

--- a/packages/graphql/components/GraphQLProvider/GraphQLProvider.tsx
+++ b/packages/graphql/components/GraphQLProvider/GraphQLProvider.tsx
@@ -20,7 +20,27 @@ export const globalApolloClient: { current: ApolloClient | null } = {
 }
 
 export type GraphQLProviderProps = AppProps &
-  Omit<ApolloClientConfigInput, 'storefront'> & { children: React.ReactNode }
+  Omit<ApolloClientConfigInput, 'storefront'> & {
+    children: React.ReactNode
+    /**
+     * Overrides the terminating link at the tail of the Apollo link chain (by default the `HttpLink`
+     * connection to the Mesh backend). Because it sits *after* every context-setting link (customer
+     * auth token, store, cache-id, header links), use it to route specific operations to a different
+     * transport while still inheriting all request headers.
+     *
+     * The motivating case is file uploads: `File`/`Blob` variables must be sent as a
+     * `multipart/form-data` request (e.g. via `apollo-upload-client`'s `UploadHttpLink`), which the
+     * default `HttpLink` cannot serialize. Providing the upload-aware split here keeps it at the tail
+     * of the chain, so uploads still pick up the customer token instead of going out unauthenticated.
+     *
+     * @example
+     *   ```tsx
+     *   const terminatingLink = ApolloLink.split(hasUploadFiles, uploadHttpLink, httpLink)
+     *   <GraphQLProvider {...props} terminatingLink={terminatingLink} />
+     *   ```
+     */
+    terminatingLink?: ApolloLink
+  }
 
 /**
  * The GraphQLProvider allows us to configure the ApolloClient and provide it to the rest of the
@@ -29,7 +49,7 @@ export type GraphQLProviderProps = AppProps &
  * Take a look at the props to see possible customization options.
  */
 export function GraphQLProvider(props: GraphQLProviderProps) {
-  const { children, links, migrations, policies, pageProps, router } = props
+  const { children, links, migrations, policies, pageProps, router, terminatingLink } = props
   const state = (pageProps as { apolloState?: unknown }).apolloState
 
   const stateRef = useRef(state)
@@ -58,8 +78,10 @@ export function GraphQLProvider(props: GraphQLProviderProps) {
     const link = ApolloLink.from([
       ...(typeof window === 'undefined' ? [errorLink, measurePerformanceLink] : []),
       ...config.current.links,
-      // The actual Http connection to the Mesh backend.
-      new HttpLink({ uri: '/api/graphql', credentials: 'same-origin' }),
+      // The actual Http connection to the Mesh backend. Overridable via `terminatingLink` so
+      // e.g. multipart file uploads can be routed to a different transport while still inheriting
+      // every header set by the links above.
+      terminatingLink ?? new HttpLink({ uri: '/api/graphql', credentials: 'same-origin' }),
     ])
 
     const cache = createCache()


### PR DESCRIPTION
## What

Adds an optional `terminatingLink?: ApolloLink` prop to `GraphQLProvider`. When provided it replaces the default `HttpLink` at the **tail** of the Apollo link chain; otherwise behaviour is unchanged.

```tsx
const terminatingLink = ApolloLink.split(hasUploadFiles, uploadHttpLink, httpLink)
<GraphQLProvider {...props} terminatingLink={terminatingLink} />
```

## Why

The terminating link runs *after* every context-setting link (customer auth token, store, cache-id, header links). Today it's a hardcoded `HttpLink`, so there's no way to route specific operations to a different transport while still inheriting those headers.

The concrete case is **file uploads**. `File`/`Blob` variables must be sent as a `multipart/form-data` request (e.g. via `apollo-upload-client`'s `UploadHttpLink`), which the default `HttpLink` cannot serialize — it JSON-stringifies the body, turning a `File` into `{}`. The only extension point today is `links`, which **prepends** to the chain: an upload link added there is a *terminating* split that fires **before** the customer-token link, so multipart requests go out without the `authorization: Bearer` header. Magento then rejects a logged-in customer's cart mutation with `The current user cannot perform operations on cart "<id>"` (guests are unaffected — no token, guest-owned cart). Supplying the upload-aware split as `terminatingLink` keeps it at the tail, so uploads inherit the token like every other operation.

## Change

- `terminatingLink ?? new HttpLink({ uri: '/api/graphql', credentials: 'same-origin' })` at the tail of the chain in `GraphQLProvider`.
- Additive, no new dependencies (`apollo-upload-client` stays in the consumer). SSR path unchanged (uploads are browser-only; non-upload SSR ops still hit the default `HttpLink`).
- Changeset: `minor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)