### PR TITLE
fix(next-config): intercept components exported via non-aliased re-export

### DIFF
--- a/.changeset/intercept-non-aliased-reexports.md
+++ b/.changeset/intercept-non-aliased-reexports.md
@@ -1,0 +1,7 @@
+---
+'@graphcommerce/next-config': patch
+---
+
+Fix plugin interceptor resolution for components exported via a non-aliased re-export.
+
+The interceptor scanner (`findOriginalSource`) only inspected an export specifier's `exported` field, which SWC leaves `null` for a non-aliased re-export such as `export { Image }` (the name lives in `orig`; `exported` is only populated by an aliased `export { Foo as Image }`). As a result, any component re-exported without an alias — e.g. `Image` from `@graphcommerce/image` — could not be targeted by a plugin and failed with "Plugin target not found". The scanner now falls back to `orig` when `exported` is absent.

--- a/packagesDev/next-config/dist/index.js
+++ b/packagesDev/next-config/dist/index.js
@@ -623,7 +623,7 @@ function parseAndFindExport(resolved, findExport, resolve) {
     if (node.type === "ExportNamedDeclaration") {
       for (const specifier of node.specifiers) {
         if (specifier.type === "ExportSpecifier") {
-          if (specifier.exported?.value === findExport) return resolved;
+          if ((specifier.exported?.value ?? specifier.orig?.value) === findExport) return resolved;
         } else if (specifier.type === "ExportDefaultSpecifier") ; else if (specifier.type === "ExportNamespaceSpecifier") ;
       }
     }

--- a/packagesDev/next-config/src/interceptors/findOriginalSource.ts
+++ b/packagesDev/next-config/src/interceptors/findOriginalSource.ts
@@ -37,7 +37,11 @@ function parseAndFindExport(
     if (node.type === 'ExportNamedDeclaration') {
       for (const specifier of node.specifiers) {
         if (specifier.type === 'ExportSpecifier') {
-          if (specifier.exported?.value === findExport) return resolved
+          // A non-aliased re-export (`export { Image }`) carries the name in
+          // `orig`, with `exported` left null; only an aliased re-export
+          // (`export { Foo as Image }`) populates `exported`. Fall back to
+          // `orig` so components exported without an alias remain interceptable.
+          if ((specifier.exported?.value ?? specifier.orig.value) === findExport) return resolved
         } else if (specifier.type === 'ExportDefaultSpecifier') {
           // todo
         } else if (specifier.type === 'ExportNamespaceSpecifier') {


### PR DESCRIPTION
## Problem

The plugin interceptor scanner (`findOriginalSource`) fails to resolve a target component that a package re-exports **without an alias**.

`parseAndFindExport` inspects each export specifier's `exported` field:

```ts
if (specifier.type === 'ExportSpecifier') {
  if (specifier.exported?.value === findExport) return resolved
}
```

But SWC only populates `exported` for an **aliased** re-export (`export { Foo as Bar }`). For a plain `export { Foo }`, the name lives in `orig` and `exported` is `null`. So any component re-exported without an alias is invisible to the scanner.

A concrete case: `@graphcommerce/image` ends `Image.tsx` with `export { Image }`. A component plugin targeting `@graphcommerce/image#Image` therefore fails at codegen with:

```
Plugin target not found @graphcommerce/image#Image for plugin ./plugins/MyPlugin#Image
```

## Fix

Fall back to `orig` when `exported` is absent — matching how `Visitor.visitNamedExportSpecifier` already treats the two fields:

```ts
if ((specifier.exported?.value ?? specifier.orig.value) === findExport) return resolved
```

Aliased re-exports keep working (they still populate `exported`); non-aliased ones now resolve too.

## Test plan

- In a consumer project, add a component plugin targeting `@graphcommerce/image#Image` and run `graphcommerce codegen-interceptors`.
- Before: `Plugin target not found @graphcommerce/image#Image`.
- After: `🆕 Creating interceptor @graphcommerce/image/components/Image` and the plugin applies at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)