### PR TITLE
fix(graphql-mesh): multipart uploads broken in next dev — customFetch/executor-http FormData mismatch

### DIFF
--- a/.changeset/mesh-upload-fetch-formdata.md
+++ b/.changeset/mesh-upload-fetch-formdata.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/graphql-mesh': patch
+---
+
+Fix multipart file uploads through the mesh returning "Unable to parse the request." in `next dev` (turbopack). `customFetch` used `globalThis.fetch` (undici) inside Next, while `@graphql-tools/executor-http` builds upload bodies with `FormData` from `@whatwg-node/fetch`. In `next dev`, `@whatwg-node/fetch` is evaluated while `next.config.ts` loads — before any `__NEXT` global exists — so its Next.js detection fails and it exports its ponyfills. Undici doesn't recognize the ponyfill `FormData` and stringified the request body to the literal `[object Object]`. `customFetch` now always uses the fetch exported by `@whatwg-node/fetch`, which is `globalThis.fetch` whenever the native path is active and the matching ponyfill fetch otherwise, so fetch and `FormData` always come from the same implementation family.

--- a/packages/graphql-mesh/customFetch.ts
+++ b/packages/graphql-mesh/customFetch.ts
@@ -2,8 +2,19 @@ import fetchRetry from 'fetch-retry'
 import type { RequestInitWithRetry } from 'fetch-retry'
 
 const fetcher = fetchRetry(
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, no-underscore-dangle, @typescript-eslint/no-var-requires
-  process.env.__NEXT_PROCESSED_ENV ? globalThis.fetch : require('@whatwg-node/fetch').fetch,
+  /**
+   * Always use the fetch that `@whatwg-node/fetch` exports, never `globalThis.fetch` directly. When
+   * `@whatwg-node/fetch` detects a Next.js runtime it re-exports the native fetch primitives (so
+   * inside Next this IS `globalThis.fetch`/undici, keeping SSL handshakes alive), but when that
+   * detection fails — `next dev` (turbopack) evaluates it while loading `next.config.ts` (via
+   * `@graphql-codegen/cli`), before any `__NEXT` global exists — it exports its ponyfills instead.
+   * In that case `@graphql-tools/executor-http` builds multipart upload bodies with the ponyfill
+   * `FormData`, which undici doesn't recognize and stringifies to the literal `[object Object]`
+   * (Magento: "Unable to parse the request."). The fetch implementation must therefore always come
+   * from the same family as the `FormData`/`File` classes executor-http uses.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-var-requires
+  require('@whatwg-node/fetch').fetch,
 )
 
 /**


### PR DESCRIPTION
## Problem

Multipart file uploads through the mesh fail in `next dev` (turbopack) with the upstream GraphQL server rejecting the request — on Magento: `"Unable to parse the request."` (400, `graphql-input`). The same build works in production.

## Cause

`customFetch` uses `globalThis.fetch` (undici) when running inside Next (`__NEXT_PROCESSED_ENV`), while `@graphql-tools/executor-http` builds multipart upload bodies with `FormData` imported from `@whatwg-node/fetch`.

`@whatwg-node/fetch` decides **at module load** whether to export the native fetch primitives or its ponyfills, via `shouldSkipPonyfill()` — which detects Next.js by looking for a `__NEXT`-prefixed key on `globalThis`. In `next dev`, `@whatwg-node/fetch` is evaluated while `next.config.ts` is being loaded (pulled in via `@graphcommerce/next-config` → `@graphql-codegen/cli`), before any `__NEXT` global exists. The detection fails, the ponyfills win, and executor-http hands a ponyfill `FormData` to undici — which doesn't recognize it and stringifies the request body to the literal `[object Object]` (15 bytes, `content-type: text/plain;charset=UTF-8`), captured with a local echo server:

```
POST /graphql
content-type: text/plain;charset=UTF-8
content-length: 15

[object Object]
```

In production the standalone server doesn't evaluate `next.config.ts` this way; by the time `@whatwg-node/fetch` loads, the Next detection succeeds, everything is native, and uploads work — which is why this only bites in dev.

## Fix

Always use the fetch that `@whatwg-node/fetch` itself exports. When the native path is active that IS `globalThis.fetch` (undici — SSL handshake keep-alive behaviour inside Next is unchanged, see 2a60491c23), and when the ponyfill path is active the fetch matches the ponyfill `FormData`/`File` classes executor-http uses. Fetch and FormData now always come from the same implementation family, whichever way the detection goes.

Verified against a Magento 2.4.8 backend: multipart upload through the dev-server mesh now succeeds; regular queries unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)