### PR TITLE
fix(next-config): forward the original module's default export in interceptors

### DIFF
--- a/.changeset/interceptor-forward-default-export.md
+++ b/.changeset/interceptor-forward-default-export.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/next-config': patch
+---
+
+Interceptors now forward the original module's default export. `export * from './X.original'` does not re-export `default` (ES semantics), so intercepting a module with a default export silently dropped it. This broke `gc-mesh build` when a plugin targeted `@graphcommerce/graphql-mesh/customFetch`: GraphQL Mesh resolves the fetch function via `exported.default || exported` and received the module namespace instead of the function, failing schema introspection with `Cannot read properties of undefined (reading '__schema')`.

--- a/packagesDev/next-config/__tests__/interceptors/generateInterceptors.ts
+++ b/packagesDev/next-config/__tests__/interceptors/generateInterceptors.ts
@@ -720,3 +720,27 @@ it('Can correctly find exports that are default exports', async () => {
     "export { iconChevronLeft as iconChevronLeft } from '../../plugins/MyProjectIcon'",
   )
 })
+
+it('forwards the default export of the original module', async () => {
+  const resolve = resolveDependency(projectRoot)
+  const interceptors = await generateInterceptors(
+    [
+      {
+        type: 'function',
+        targetExport: 'fetch',
+        sourceExport: 'fetch',
+        enabled: true,
+        targetModule: '@graphcommerce/graphql-mesh/customFetch',
+        sourceModule: './plugins/MyCustomFetch',
+      },
+    ],
+    resolve,
+  )
+  const result = interceptors['packages/graphql-mesh/customFetch']?.template
+
+  // `export *` does not include the default export; without an explicit forward, consumers that
+  // import the default (e.g. GraphQL Mesh resolving customFetch via `exported.default ||
+  // exported`) would receive the module namespace instead of the function.
+  expect(result).toContain("export * from './customFetch.original'")
+  expect(result).toContain("export { default } from './customFetch.original'")
+})

--- a/packagesDev/next-config/src/interceptors/generateInterceptor.ts
+++ b/packagesDev/next-config/src/interceptors/generateInterceptor.ts
@@ -2,6 +2,7 @@ import prettierConf from '@graphcommerce/prettier-config-pwa'
 import prettier from 'prettier'
 import type { GraphCommerceDebugConfig } from '../generated/config'
 import type { ResolveDependencyReturn } from '../utils/resolveDependency'
+import { parseSync } from './swc'
 
 type PluginBaseConfig = {
   type: 'component' | 'function' | 'replace'
@@ -107,6 +108,34 @@ const stableStringify = (obj: any): string => {
   const keys = Object.keys(obj).sort()
   const pairs = keys.map((key) => `${JSON.stringify(key)}:${stableStringify(obj[key])}`)
   return `{${pairs.join(',')}}`
+}
+
+/**
+ * `export * from './X.original'` does not re-export the original module's default export (ES
+ * semantics), so an intercepted module would silently lose it. Consumers that prefer the default
+ * export (e.g. GraphQL Mesh's getPackage does `exported.default || exported` to resolve
+ * `customFetch`) then receive the whole module namespace instead of the function, which breaks at
+ * runtime. Detect a default export so the interceptor can forward it explicitly.
+ *
+ * On regeneration the resolved source may be a previously generated interceptor; its emitted
+ * `export { default } from './X.original'` is an ExportNamedDeclaration with a `default` specifier
+ * and is detected the same way, keeping the output stable.
+ */
+function hasDefaultExport(source: string): boolean {
+  try {
+    return parseSync(source).body.some((node) => {
+      if (node.type === 'ExportDefaultDeclaration' || node.type === 'ExportDefaultExpression')
+        return true
+      if (node.type === 'ExportNamedDeclaration') {
+        return node.specifiers.some(
+          (s) => s.type === 'ExportSpecifier' && (s.exported ?? s.orig).value === 'default',
+        )
+      }
+      return false
+    })
+  } catch {
+    return false
+  }
 }
 
 /**
@@ -340,7 +369,12 @@ export const ${targetExport} = ${carry}`
 
     // Re-export everything from the original file except the intercepted exports
     export * from './${interceptor.target.split('/').pop()}.original'
-
+    ${
+      hasDefaultExport(interceptor.source)
+        ? `\n    // Forward the original module's default export: \`export *\` does not include it.
+    export { default } from './${interceptor.target.split('/').pop()}.original'\n`
+        : ''
+    }
     ${logOnce}${pluginExports}
   `
 


### PR DESCRIPTION
## What

Generated interceptors re-export the original module with `export * from './X.original'`, but `export *` does not include the `default` export (ES semantics). Any intercepted module that has a default export silently loses it.

The interceptor generator now detects a default export in the resolved source (via SWC) and adds:

```ts
export { default } from './X.original'
```

## Why

A `type: 'function'` plugin targeting `@graphcommerce/graphql-mesh/customFetch` broke `gc-mesh build`: GraphQL Mesh's `getPackage` resolves the custom fetch via `exported.default || exported`, so it received the module namespace object instead of the fetch function. Schema introspection then failed with:

```
Failed to fetch introspection from …/graphql: TypeError: Cannot read properties of undefined (reading '__schema')
```

Note that the forwarded default is the **original** (unintercepted) export — plugin chains only wrap named exports. For the Mesh case that is also the desired behavior: the runtime `.mesh` artifact imports the wrapped named export (`m?.fetch || m`), while the Mesh CLI's introspection uses the vanilla fetch.

Detection stays stable across regenerations: a previously generated interceptor contains the emitted `export { default } from './X.original'`, which is detected the same way.

## Test

Added a test in `packagesDev/next-config/__tests__/interceptors/generateInterceptors.ts` targeting `@graphcommerce/graphql-mesh/customFetch` (which has `export default fetch`). Existing snapshots are unchanged (modules without a default export get no extra line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)