### PR TITLE
feat(graphql-mesh): route Magento traffic over an internal network via GC_MAGENTO_ENDPOINT_SERVER

### DIFF
--- a/.changeset/magento-server-endpoint.md
+++ b/.changeset/magento-server-endpoint.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/graphql-mesh': minor
+---
+
+Route server-side Magento traffic over an internal network with the new runtime-only `GC_MAGENTO_ENDPOINT_SERVER` environment variable (e.g. `http://varnish.magento-namespace.svc.cluster.local`). When set, every mesh request whose URL starts with the origin of `GC_MAGENTO_ENDPOINT` — GraphQL and REST — is rewritten to the internal origin and gains an `X-Forwarded-Proto: https` header, so frontend↔Magento traffic inside a Kubernetes cluster no longer hairpins over the public load balancer. Unset, behavior is unchanged. See the new "Routing Magento traffic over an internal network" section in the mesh docs.

--- a/docs/framework/mesh.md
+++ b/docs/framework/mesh.md
@@ -92,3 +92,35 @@ To make sure changes are picked up during development set the config value
 `graphqlMeshEditMode: true` in your graphcommerce.config.js or set the env
 variable `GC_GRAPHQL_MESH_EDIT_MODE=1`. This _will_ make the frontend
 considerably slower.
+
+## Routing Magento traffic over an internal network
+
+When the frontend runs next to Magento — e.g. both in the same Kubernetes
+cluster — the mesh's server-side Magento requests (GraphQL and REST) can be
+routed directly to an internal Service instead of hairpinning over the public
+load balancer. Set in the **runtime** environment (e.g. a Kubernetes
+ConfigMap):
+
+```
+GC_MAGENTO_ENDPOINT_SERVER=http://varnish.magento-namespace.svc.cluster.local
+```
+
+Every request whose URL starts with the origin of `GC_MAGENTO_ENDPOINT` is
+rewritten to this origin, so both the GraphQL endpoint and the REST endpoint
+are covered. `GC_MAGENTO_ENDPOINT` itself stays the public URL: it keeps
+feeding build-time schema introspection, `images.remotePatterns` and the media
+URLs Magento generates. The rewrite also sends `X-Forwarded-Proto: https`,
+which the TLS-terminating proxy would normally add — Magento needs it to keep
+generating `https://` URLs.
+
+Caveats:
+
+- Both `GC_MAGENTO_ENDPOINT_SERVER` and `GC_MAGENTO_ENDPOINT` must be present
+  in the runtime environment; the rewrite happens per request at runtime.
+- Do **not** set `GC_MAGENTO_ENDPOINT_SERVER` in the build environment: schema
+  introspection (`gc-mesh build`) and static generation run where the internal
+  endpoint is typically not reachable. Unset, the feature is a no-op.
+- Point it at the Varnish service (not the webserver directly) to keep
+  Magento's GraphQL full-page cache in the path.
+- When a NetworkPolicy guards the Magento namespace, allow ingress from the
+  frontend namespace to the Varnish pods.

--- a/packages/graphql-mesh/customFetch.ts
+++ b/packages/graphql-mesh/customFetch.ts
@@ -18,6 +18,45 @@ const fetcher = fetchRetry(
 )
 
 /**
+ * Optionally reroute server-side Magento traffic to an internal endpoint.
+ *
+ * When the runtime environment sets `GC_MAGENTO_ENDPOINT_SERVER` (e.g.
+ * `http://varnish.magento-namespace.svc.cluster.local`), every request whose URL starts with the
+ * origin of `GC_MAGENTO_ENDPOINT` is rewritten to that origin. All Magento traffic the mesh
+ * performs (GraphQL and REST) then stays on the internal network — e.g. within a Kubernetes cluster
+ * — instead of hairpinning over the public load balancer, while the public endpoint keeps serving
+ * the browser-facing concerns (media URLs, image optimization).
+ *
+ * - Both variables are read from `process.env` at request time: this module also runs outside the
+ *   Next.js bundler (the mesh CLI imports it during `gc-mesh build`), so it cannot rely on
+ *   build-inlined configuration.
+ * - Set `GC_MAGENTO_ENDPOINT_SERVER` in the runtime environment only (e.g. a Kubernetes ConfigMap),
+ *   never in the build environment: schema introspection and static generation run where the
+ *   internal endpoint is not reachable. Unset, this is a no-op.
+ * - The rewrite adds `X-Forwarded-Proto: https` — the internal path bypasses the TLS-terminating
+ *   proxy that normally adds it, and without it Magento considers the request insecure and
+ *   generates http:// URLs in responses.
+ */
+function toServerEndpoint(
+  url: RequestInfo | URL,
+  options: RequestInitWithRetry | undefined,
+): [RequestInfo | URL, RequestInitWithRetry | undefined] {
+  const serverEndpoint = process.env.GC_MAGENTO_ENDPOINT_SERVER
+  const publicEndpoint = process.env.GC_MAGENTO_ENDPOINT
+  if (!serverEndpoint || !publicEndpoint) return [url, options]
+  if (typeof url !== 'string' && !(url instanceof URL)) return [url, options]
+
+  const publicOrigin = new URL(publicEndpoint).origin
+  const target = url.toString()
+  if (!target.startsWith(publicOrigin)) return [url, options]
+
+  return [
+    new URL(serverEndpoint).origin + target.slice(publicOrigin.length),
+    { ...options, headers: { ...options?.headers, 'x-forwarded-proto': 'https' } },
+  ]
+}
+
+/**
  * @param {RequestInfo | URL} url
  * @param {import('fetch-retry').RequestInitWithRetry | undefined} options
  * @returns {Promise<Response>}
@@ -27,12 +66,14 @@ export const fetch = (
   url: RequestInfo | URL,
   options: RequestInitWithRetry | undefined,
 ): Promise<Response> => {
+  const [serverUrl, serverOptions] = toServerEndpoint(url, options)
+
   const headers = Object.fromEntries(
-    Object.entries(options?.headers ?? {}).filter(([, value]) => value !== ''),
+    Object.entries(serverOptions?.headers ?? {}).filter(([, value]) => value !== ''),
   )
 
-  return fetcher(url, {
-    ...options,
+  return fetcher(serverUrl, {
+    ...serverOptions,
     headers,
     retries: 6,
     retryDelay: (attempt) => 2 ** attempt * 200, // 200, 400, 800, 1600, 3200, 6400


### PR DESCRIPTION
## What

Adds an opt-in, runtime-only environment variable `GC_MAGENTO_ENDPOINT_SERVER`. When set (e.g. `http://varnish.magento-namespace.svc.cluster.local`), `customFetch` rewrites every request whose URL starts with the origin of `GC_MAGENTO_ENDPOINT` to the internal origin — covering both the GraphQL endpoint and the REST endpoint — and adds `X-Forwarded-Proto: https`. Unset, behavior is unchanged.

## Why

When the frontend runs next to Magento (same Kubernetes cluster), all server-side Magento traffic otherwise hairpins over the public load balancer: public DNS → LB → gateway → TLS → Varnish → Magento. Routing it to the in-cluster Varnish Service directly removes the LB/gateway/TLS hops while browser-facing concerns (media URLs, image optimization, build-time introspection) keep using the public `GC_MAGENTO_ENDPOINT`.

Design notes:

- **Runtime-only, read per request from `process.env`**: `customFetch` also runs outside the Next.js bundler (the mesh CLI imports it during `gc-mesh build`), so it cannot rely on build-inlined config. It also must not apply at build time — introspection/SSG run where the internal endpoint is unreachable. Docs warn to set it only in the runtime environment (e.g. a Kubernetes ConfigMap).
- **`X-Forwarded-Proto: https`** replaces what the TLS-terminating proxy normally adds; without it Magento considers the request insecure and generates `http://` URLs in responses.
- Verified in production-like conditions on a Kubernetes deployment (GC and Magento in separate namespaces, Varnish in the path, NetworkPolicy allowing frontend→Varnish): Varnish access logs show `POST /graphql 200` directly from the frontend pod IPs, media URLs stay `https://`.

Documented in a new "Routing Magento traffic over an internal network" section in `docs/framework/mesh.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)