### PR TITLE
PlaceOrderOutput.errors is nullable since Magento 2.4.9

### DIFF
--- a/.changeset/place-order-errors-nullable.md
+++ b/.changeset/place-order-errors-nullable.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/magento-graphql': patch
+---
+
+Relax `PlaceOrderOutput.errors` to nullable in the unified schema. Magento 2.4.9 / MageOS 3.2.0 changed the field from `[PlaceOrderError]!` to `[PlaceOrderError]` and returns `null` when the order is placed successfully, so a storefront configured with `magentoVersion` < 249 talking to a 2.4.9 backend failed every successful order with `Cannot return null for non-nullable field PlaceOrderOutput.errors.`

--- a/packages/magento-graphql/schema-249/PlaceOrderOutput.graphqls
+++ b/packages/magento-graphql/schema-249/PlaceOrderOutput.graphqls
@@ -1,0 +1,12 @@
+# Magento 2.4.9 (and MageOS 3.2.0) relaxed `PlaceOrderOutput.errors` from
+# `[PlaceOrderError]!` to `[PlaceOrderError]` and now returns `null` when the
+# order is placed successfully. The unified schema must use the nullable
+# variant, otherwise the mesh throws "Cannot return null for non-nullable field
+# PlaceOrderOutput.errors." on every successful placeOrder once the backend
+# runs 2.4.9, while a 2.4.8 backend still satisfies the relaxed contract.
+type PlaceOrderOutput {
+  """
+  An array of place order errors. Returns null on success since Magento 2.4.9.
+  """
+  errors: [PlaceOrderError]
+}


### PR DESCRIPTION
Magento 2.4.9 / MageOS 3.2.0 relaxed `PlaceOrderOutput.errors` from `[PlaceOrderError]!` to `[PlaceOrderError]` and the resolver now returns `null` when the order is placed successfully (see the schema diff: https://github.com/ho-nl/magento2-graphql-versions/compare/2.4.8...2.4.9#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489L8943-R9032).

A mesh whose unified schema still declares the field non-null (introspected from an older backend, or any `magentoVersion` < 249 setup) then fails **every successful order** at the gateway with:

```
Cannot return null for non-nullable field PlaceOrderOutput.errors.
```

while the order *is* placed in Magento — the customer just sees a generic payment error.

### Fix

Add `packages/magento-graphql/schema-249/PlaceOrderOutput.graphqls` redeclaring `errors` as nullable. The `schema-249` additionalTypeDefs are applied for every project with `magentoVersion` < 249, so the unified schema always carries the loosest contract across supported Magento versions:

- 2.4.9 backend + `magentoVersion: 248`: mesh no longer bombs on `errors: null` (this was the bug).
- 2.4.8 backend: still returns a non-null list, which trivially satisfies the nullable field.
- `magentoVersion: 249`: typedef not applied; live introspection is already nullable.

Verified that stitching merges a partial type redefinition as expected: `errors` becomes nullable while `order` / `orderV2` and the rest of the introspected type are preserved. Client code (`assertOrderPlaced`, `PaymentMethodPlaceOrderNoop`) already handles `errors: null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)