### PR TITLE
fix(next-config): redirect Magento account URLs to the GraphCommerce routes

### DIFF
--- a/.changeset/redirect-magento-customer-account-urls.md
+++ b/.changeset/redirect-magento-customer-account-urls.md
@@ -1,0 +1,11 @@
+---
+'@graphcommerce/next-config': patch
+---
+
+Redirect the Magento frontend account URLs that end up in transactional emails to their GraphCommerce equivalents.
+
+Magento renders links from `base_link_url`, which on a headless setup points at the GraphCommerce storefront. Every stock email template contains a `customer/account/` link ("Sign in to your account"), and gated Magento routes 302 to `customer/account/login` — none of which GraphCommerce serves, so customers landed on a 404.
+
+`withGraphCommerce` now adds permanent redirects for `/customer/account`, `/customer/account/index`, `/customer/account/login`, `/customer/account/create`, `/customer/account/forgotpassword` and `/sales/order/history`. They are exact matches on purpose: redirects run before the filesystem routes, so a `/customer/account/:path*` catch-all would shadow the `pages/customer/account/{confirm,createPassword}` routes that `@graphcommerce/magento-customer` copies into the project.
+
+This restores the `/customer/account` redirect that was dropped as collateral in "Remove redirects for `/product/$type/[url]` routes".

--- a/.changeset/redirect-magento-customer-account-urls.md
+++ b/.changeset/redirect-magento-customer-account-urls.md
@@ -6,6 +6,6 @@ Redirect the Magento frontend account URLs that end up in transactional emails t
 
 Magento renders links from `base_link_url`, which on a headless setup points at the GraphCommerce storefront. Every stock email template contains a `customer/account/` link ("Sign in to your account"), and gated Magento routes 302 to `customer/account/login` — none of which GraphCommerce serves, so customers landed on a 404.
 
-`withGraphCommerce` now adds permanent redirects for `/customer/account`, `/customer/account/index`, `/customer/account/login`, `/customer/account/create`, `/customer/account/forgotpassword` and `/sales/order/history`. They are exact matches on purpose: redirects run before the filesystem routes, so a `/customer/account/:path*` catch-all would shadow the `pages/customer/account/{confirm,createPassword}` routes that `@graphcommerce/magento-customer` copies into the project.
+`withGraphCommerce` now adds permanent redirects for `/customer/account`, `/customer/account/index`, `/customer/account/login`, `/customer/account/create` and `/sales/order/history`. They are exact matches on purpose: a redirect wins over a filesystem route, and `/customer/account/confirm` and `/customer/account/createPassword` are real pages in the examples — the two that carry Magento's confirmation `key` and reset `rp_token`. A `/customer/account/:path*` catch-all would make both unreachable.
 
 This restores the `/customer/account` redirect that was dropped as collateral in "Remove redirects for `/product/$type/[url]` routes".

--- a/packagesDev/next-config/dist/index.js
+++ b/packagesDev/next-config/dist/index.js
@@ -1660,6 +1660,32 @@ function withGraphCommerce(nextConfig, cwd = process.cwd()) {
         ...nextConfig.images?.remotePatterns ?? []
       ].filter((v) => !!v)
     },
+    redirects: async () => {
+      const redirects = await nextConfig.redirects?.() ?? [];
+      // Magento builds its own frontend URLs from `base_link_url`, which on a
+      // headless setup points at the GraphCommerce storefront. Those URLs end up
+      // in transactional emails ("Sign in to your account" links every stock
+      // email template renders) and in the 302 Location of gated Magento routes,
+      // but GraphCommerce doesn't serve them, so they 404.
+      //
+      // These have to stay exact matches: redirects are evaluated *before* the
+      // filesystem routes, so a `/customer/account/:path*` catch-all would
+      // shadow the pages/customer/account/{confirm,createPassword} routes that
+      // @graphcommerce/magento-customer copies into the project.
+      redirects.push(
+        { source: "/customer/account", destination: "/account", permanent: true },
+        { source: "/customer/account/index", destination: "/account", permanent: true },
+        { source: "/customer/account/login", destination: "/account/signin", permanent: true },
+        { source: "/customer/account/create", destination: "/account/signin", permanent: true },
+        {
+          source: "/customer/account/forgotpassword",
+          destination: "/account/forgot-password",
+          permanent: true
+        },
+        { source: "/sales/order/history", destination: "/account/orders", permanent: true }
+      );
+      return redirects;
+    },
     rewrites: async () => {
       let rewrites = await nextConfig.rewrites?.() ?? [];
       if (Array.isArray(rewrites)) {

--- a/packagesDev/next-config/dist/index.js
+++ b/packagesDev/next-config/dist/index.js
@@ -1668,20 +1668,17 @@ function withGraphCommerce(nextConfig, cwd = process.cwd()) {
       // email template renders) and in the 302 Location of gated Magento routes,
       // but GraphCommerce doesn't serve them, so they 404.
       //
-      // These have to stay exact matches: redirects are evaluated *before* the
-      // filesystem routes, so a `/customer/account/:path*` catch-all would
-      // shadow the pages/customer/account/{confirm,createPassword} routes that
-      // @graphcommerce/magento-customer copies into the project.
+      // A redirect wins over a filesystem route, so every source below must be
+      // a path GraphCommerce does *not* serve. Two Magento paths are real pages
+      // in the examples — /customer/account/confirm and
+      // /customer/account/createPassword, the ones carrying the confirmation
+      // `key` and the reset `rp_token` — so these stay exact matches. A
+      // `/customer/account/:path*` catch-all would make both unreachable.
       redirects.push(
         { source: "/customer/account", destination: "/account", permanent: true },
         { source: "/customer/account/index", destination: "/account", permanent: true },
         { source: "/customer/account/login", destination: "/account/signin", permanent: true },
         { source: "/customer/account/create", destination: "/account/signin", permanent: true },
-        {
-          source: "/customer/account/forgotpassword",
-          destination: "/account/forgot-password",
-          permanent: true
-        },
         { source: "/sales/order/history", destination: "/account/orders", permanent: true }
       );
       return redirects;

--- a/packagesDev/next-config/src/withGraphCommerce.ts
+++ b/packagesDev/next-config/src/withGraphCommerce.ts
@@ -102,6 +102,34 @@ export function withGraphCommerce(nextConfig: NextConfig, cwd: string = process.
         ...(nextConfig.images?.remotePatterns ?? []),
       ].filter((v) => !!v),
     },
+    redirects: async () => {
+      const redirects = (await nextConfig.redirects?.()) ?? []
+
+      // Magento builds its own frontend URLs from `base_link_url`, which on a
+      // headless setup points at the GraphCommerce storefront. Those URLs end up
+      // in transactional emails ("Sign in to your account" links every stock
+      // email template renders) and in the 302 Location of gated Magento routes,
+      // but GraphCommerce doesn't serve them, so they 404.
+      //
+      // These have to stay exact matches: redirects are evaluated *before* the
+      // filesystem routes, so a `/customer/account/:path*` catch-all would
+      // shadow the pages/customer/account/{confirm,createPassword} routes that
+      // @graphcommerce/magento-customer copies into the project.
+      redirects.push(
+        { source: '/customer/account', destination: '/account', permanent: true },
+        { source: '/customer/account/index', destination: '/account', permanent: true },
+        { source: '/customer/account/login', destination: '/account/signin', permanent: true },
+        { source: '/customer/account/create', destination: '/account/signin', permanent: true },
+        {
+          source: '/customer/account/forgotpassword',
+          destination: '/account/forgot-password',
+          permanent: true,
+        },
+        { source: '/sales/order/history', destination: '/account/orders', permanent: true },
+      )
+
+      return redirects
+    },
     rewrites: async () => {
       let rewrites = (await nextConfig.rewrites?.()) ?? []
 

--- a/packagesDev/next-config/src/withGraphCommerce.ts
+++ b/packagesDev/next-config/src/withGraphCommerce.ts
@@ -111,20 +111,17 @@ export function withGraphCommerce(nextConfig: NextConfig, cwd: string = process.
       // email template renders) and in the 302 Location of gated Magento routes,
       // but GraphCommerce doesn't serve them, so they 404.
       //
-      // These have to stay exact matches: redirects are evaluated *before* the
-      // filesystem routes, so a `/customer/account/:path*` catch-all would
-      // shadow the pages/customer/account/{confirm,createPassword} routes that
-      // @graphcommerce/magento-customer copies into the project.
+      // A redirect wins over a filesystem route, so every source below must be
+      // a path GraphCommerce does *not* serve. Two Magento paths are real pages
+      // in the examples — /customer/account/confirm and
+      // /customer/account/createPassword, the ones carrying the confirmation
+      // `key` and the reset `rp_token` — so these stay exact matches. A
+      // `/customer/account/:path*` catch-all would make both unreachable.
       redirects.push(
         { source: '/customer/account', destination: '/account', permanent: true },
         { source: '/customer/account/index', destination: '/account', permanent: true },
         { source: '/customer/account/login', destination: '/account/signin', permanent: true },
         { source: '/customer/account/create', destination: '/account/signin', permanent: true },
-        {
-          source: '/customer/account/forgotpassword',
-          destination: '/account/forgot-password',
-          permanent: true,
-        },
         { source: '/sales/order/history', destination: '/account/orders', permanent: true },
       )
 


### PR DESCRIPTION
_Written by Claude Code:_

Magento builds its own frontend URLs from `base_link_url`. On a headless setup that value points at the GraphCommerce storefront, so every stock transactional email ships a link GraphCommerce cannot serve:

```
$ grep -rEho "'[a-z_]+/[a-z_]+/?[a-zA-Z_]*/?'" $(find vendor -path '*/email/*.html')
  48 'customer/account/'
  10 'customer/account/createPassword/'
   2 'customer/account/createPassword'
   2 'customer/account/confirm/'
```

`createPassword` and `confirm` are covered — all three examples ship `pages/customer/account/{confirm,createPassword}` (they are scaffolded from the examples; `@graphcommerce/magento-customer` has no `copy/` directory). `customer/account/` is not, and it is the single most common link in the whole email set ("Sign in to your account", in the footer of every order/invoice/shipment/credit-memo mail). It 404s.

There used to be exactly this redirect, added in #1936 and moved into `withGraphCommerce` shortly after. It was dropped as collateral in "Remove redirects for `/product/$type/[url]` routes" (2c79a4cb) — that commit removed the whole `redirects()` block, and the `/customer/account` entry happened to live in the same array. This restores it and adds the neighbouring URLs that Magento also emits.

## The list

| Magento URL | GraphCommerce route | Where it comes from |
| --- | --- | --- |
| `/customer/account` | `/account` | every stock email template |
| `/customer/account/index` | `/account` | Magento's canonical alias for the dashboard |
| `/customer/account/login` | `/account/signin` | 302 `Location` on gated Magento routes — `magento-product-downloadable`'s copy pages already sniff for this string |
| `/customer/account/create` | `/account/signin` | registration links; `/account/signin` renders both sign-in and sign-up |
| `/sales/order/history` | `/account/orders` | Magento's "My Orders" |

## Why exact matches, not `:path*`

A `redirects()` entry is evaluated **before** the filesystem routes, so redirecting a path that has a page makes that page unreachable. GraphCommerce serves exactly two paths under `/customer/`: `confirm` and `createPassword` — the two carrying Magento's one-shot confirmation `key` and reset `rp_token`. A catch-all would break account confirmation and password reset outright, so every entry stays an exact source. Note that `/customer/account/create` is a distinct route from `/customer/account/createPassword` and does not cover it.

**Dropped after review** (a3a45d2fe9): `/customer/account/forgotpassword` was in the first revision. It shadows nothing — there is no `forgotpassword` page anywhere in the examples — but it appears in zero email templates, and Magento's reset token rides on `createPassword`, not on it. No evidence, so it's gone.

## Notes

- Projects that already define their own `redirects()` keep working: `withGraphCommerce` awaits `nextConfig.redirects()` first and appends, and Next.js takes the first match, so a project override wins.
- `dist/index.js` is updated alongside `src/` per the convention in this package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

