### PR TITLE
fix(storyblok-ui): resolve story multilinks to the target's current slug

### DIFF
--- a/.changeset/storyblok-multilink-prefer-resolved-full-slug.md
+++ b/.changeset/storyblok-multilink-prefer-resolved-full-slug.md
@@ -1,0 +1,5 @@
+---
+'@graphcommerce/storyblok-ui': patch
+---
+
+Resolve `story` multilinks against the target's current slug instead of the frozen `cached_url`. `cached_url` is a snapshot taken when the *referencing* story was last published, so renaming the target left every link to it pointing at a 404 until an editor re-published each referencing story. `multilinkHref` now prefers `story.full_slug` — populated from the `links` map the CDN resolves on every read, since `sbParams` always sends `resolve_links: 'story'` — which makes story links self-healing across renames. Other link types are unaffected.

--- a/packages/storyblok-ui/lib/multilinkHref.ts
+++ b/packages/storyblok-ui/lib/multilinkHref.ts
@@ -13,14 +13,31 @@ export type StoryblokMultilink = {
 }
 
 /**
- * Extracts a usable href from a Storyblok `multilink` field. Accepts
- * `cached_url` first (the editor-friendly short path), then `url`, then
- * `email` (prefixed with `mailto:` if not already). Returns an empty string
- * for unset or empty links so callers can pass it straight to `href` without
- * a nullish check.
+ * Extracts a usable href from a Storyblok `multilink` field. Accepts the
+ * resolved story slug first, then `cached_url` (the editor-friendly short
+ * path), then `url`, then `email` (prefixed with `mailto:` if not already).
+ * Returns an empty string for unset or empty links so callers can pass it
+ * straight to `href` without a nullish check.
+ *
+ * A `story` multilink carries the target twice, and only one of the two is
+ * current:
+ *
+ * - `cached_url` is the target's `full_slug` as it was when the *referencing*
+ *   story was last published. Renaming the target does not rewrite it in
+ *   already-published content, so it keeps producing the old (now 404ing) URL
+ *   until an editor re-publishes every story that links to the renamed one.
+ * - `story.full_slug` is injected by `@storyblok/react` from the `links` map
+ *   the CDN builds from the live story index on every request. `sbParams`
+ *   sends `resolve_links: 'story'` on all reads, so it is populated for story
+ *   links and always reflects the target's current slug.
+ *
+ * Preferring the resolved slug makes story links self-healing across renames.
+ * Other link types (`url` / `email` / `asset`) have no resolved story and fall
+ * through unchanged.
  */
 export function multilinkHref(link?: StoryblokMultilink | null): string {
   if (!link) return ''
+  if (link.linktype === 'story' && link.story?.full_slug) return link.story.full_slug
   if (link.cached_url) return link.cached_url
   if (link.url) return link.url
   if (link.email) return link.email.startsWith('mailto:') ? link.email : `mailto:${link.email}`


### PR DESCRIPTION
_Written by Claude Code:_

A `story` multilink carries the target twice, and only one of the two is current:

| field | meaning |
|---|---|
| `cached_url` | the target's `full_slug` **as it was when the referencing story was last published**. Renaming the target does not rewrite it in already-published content. |
| `story.full_slug` | injected by `@storyblok/react` from the `links` map the CDN builds from the live story index on every request. `sbParams` already sends `resolve_links: 'story'` on all reads, so it is populated for every story link. |

`multilinkHref` preferred `cached_url`, so renaming a story left every link to it emitting the old URL — a 404 — until an editor re-published each referencing story individually. That is easy to miss for links in a shared global-config story: the config is embedded in each page's `getStaticProps` output, so the stale href also lingers per page for as long as that page's ISR entry lives, making the same link appear broken on some routes and fine on others.

This PR prefers the resolved `story.full_slug` for `linktype: 'story'`, which makes story links self-healing across renames — no re-publish of referencing stories needed. `url` / `email` / `asset` links have no resolved story and fall through to the existing behaviour unchanged.

Found on a production storefront where the footer's "Retourneren" link pointed at `/klantenservice/Retourneren` after the target story had been renamed to lowercase `retourneren`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
