### PR TITLE
feat(magento-cart-payment-method): let onSuccess add success-page query params

### DIFF
--- a/.changeset/olive-pumas-invent.md
+++ b/.changeset/olive-pumas-invent.md
@@ -1,0 +1,9 @@
+---
+'@graphcommerce/magento-cart-payment-method': patch
+---
+
+Allow payment handlers to add query parameters to the success page: the context's `onSuccess` takes an optional second argument that is merged into the success URL's query.
+
+Without it, a handler that needs an extra parameter on the success page — a "payment is still being confirmed" flag, for instance — has to navigate there itself, which skips `onSuccess`'s first step and silently drops purchase tracking and any plugin hanging off it.
+
+The extra query is merged after `order_number` and `cart_id`, so a handler holding a more reliable cart id (one whose cart the context has already lost) can pass its own.

--- a/packages/magento-cart-payment-method/PaymentMethodContext/PaymentMethodContext.tsx
+++ b/packages/magento-cart-payment-method/PaymentMethodContext/PaymentMethodContext.tsx
@@ -19,6 +19,14 @@ export type PaymentMethodContextProviderProps = {
   modules?: PaymentMethodModules
   children: React.ReactNode
   successUrl?: string
+  /**
+   * Runs when the order is placed, before navigating to the success page. This is where purchase
+   * tracking hangs (see the `google-datalayer` plugin on this component).
+   *
+   * Not to be confused with the context's `onSuccess`, which payment handlers call to *trigger*
+   * this: that one takes the success page's query parameters as its second argument, this one
+   * receives the cart being checked out.
+   */
   onSuccess?: (
     orderNumber: string,
     cart?: PaymentMethodContextFragment | null,
@@ -45,11 +53,13 @@ export function PaymentMethodContextProvider(props: PaymentMethodContextProvider
   )
 
   const onSuccessCb: NonNullable<PaymentMethodContextType['onSuccess']> = useEventCallback(
-    async (orderNumber) => {
+    async (orderNumber, query) => {
       await onSuccess?.(orderNumber, context.data?.cart)
       await push({
         pathname: successUrl,
-        query: { order_number: orderNumber, cart_id: context.data?.cart?.id },
+        // `query` last: a payment handler that supplies its own `cart_id` knows it better than the
+        // context does, which by this point may already have lost the cart it is reading from.
+        query: { order_number: orderNumber, cart_id: context.data?.cart?.id, ...query },
       })
       clearCurrentCartId()
     },

--- a/packages/magento-cart-payment-method/PaymentMethodContext/paymentMethodContextType.ts
+++ b/packages/magento-cart-payment-method/PaymentMethodContext/paymentMethodContextType.ts
@@ -1,3 +1,4 @@
+import type { ParsedUrlQueryInput } from 'querystring'
 import { createContext, useContext } from 'react'
 import type { PaymentMethod, PaymentMethodModules, PaymentModule } from '../Api/PaymentMethod'
 
@@ -8,7 +9,20 @@ export type PaymentMethodContextType = {
   modules: PaymentMethodModules
   selectedModule?: PaymentModule
   setSelectedModule: (module: PaymentModule | undefined) => void
-  onSuccess: (orderNumber: string) => Promise<void>
+
+  /**
+   * Completes the checkout: runs the provider's `onSuccess` hook — purchase tracking, and whatever
+   * plugins have attached themselves to it — then navigates to the success page and clears the cart
+   * id, in that order.
+   *
+   * Payment handlers should always finish through here rather than navigating to the success page
+   * themselves, otherwise that hook silently does not run.
+   *
+   * @param query Extra query parameters for the success page, e.g. a flag saying the payment is
+   *   still being confirmed. Merged _over_ `order_number` and `cart_id`, so a handler that knows
+   *   the cart id better than the provider does can supply its own.
+   */
+  onSuccess: (orderNumber: string, query?: ParsedUrlQueryInput) => Promise<void>
 }
 
 export const paymentMethodContext = createContext<PaymentMethodContextType | undefined>(undefined)


### PR DESCRIPTION
_Written by Claude Code:_

## Problem

`PaymentMethodContextProvider` hands payment handlers one `onSuccess` to finish a checkout with, and
the order of what it does is load-bearing:

```tsx
async (orderNumber) => {
  await onSuccess?.(orderNumber, context.data?.cart)   // ← the provider's hook
  await push({ pathname: successUrl, query: { order_number: orderNumber, cart_id: … } })
  clearCurrentCartId()
}
```

That first line is where purchase tracking lives — `@graphcommerce/google-datalayer` ships a
component plugin on this very component that wraps the `onSuccess` prop and fires
`sendEvent('purchase', cartToPurchase(orderNumber, cart))`, which `googleanalytics` and
`googletagmanager` then pick up through their own function plugins on `sendEvent`. Any project
passing its own `onSuccess` prop hangs off the same line.

A handler that needs one extra query parameter on the success page had no way to ask for it. The
only option was to skip the callback and navigate itself:

```tsx
clearCurrentCartId()
router.push({ pathname: '/checkout/success', query: { order_number, cart_id, pay_pending: '1' } })
```

…which silently drops the purchase event and every plugin attached to it. Nothing errors, the
shopper lands on the right page, and the analytics gap only surfaces later. We hit exactly this in a
Pay. (Pay.nl) handler that has to mark a payment as still being confirmed.

## Change

The context's `onSuccess` takes an optional second argument, merged into the success URL's query:

```tsx
onSuccess: (orderNumber: string, query?: ParsedUrlQueryInput) => Promise<void>
```

```tsx
await push({
  pathname: successUrl,
  query: { order_number: orderNumber, cart_id: context.data?.cart?.id, ...query },
})
```

`ParsedUrlQueryInput` from `querystring` — the type `router.push`'s query accepts, and `querystring`
is already the source of URL query types elsewhere in the repo (`next-ui/Page/types.ts`,
`magento-store/utils/redirectOrNotFound.ts`).

### Why the extra query merges last

Spreading it after `order_number`/`cart_id` means a caller *can* replace them. That is deliberate,
not an oversight:

- A handler returning from an external gateway frequently holds a more reliable cart id than the
  context does. `cart_id` here comes from `context.data?.cart?.id`, a `useCartQuery` whose cart may
  have been invalidated or locked by the time the browser comes back; a handler that kept the id in
  its own lock state can simply pass it.
- The protection a "defaults win" merge would buy is thin. This argument is opt-in — a caller has to
  write `order_number` explicitly to clobber it — so it guards against nothing that a typo would not
  equally cause in the object it is already constructing.

Documented on the type so the precedence is not a surprise.

### The two `onSuccess`es do not collide

`PaymentMethodContextProviderProps.onSuccess` already has a second parameter (`cart`). It is a
different callback in the opposite direction:

| | `PaymentMethodContextProviderProps.onSuccess` (prop) | `PaymentMethodContextType.onSuccess` (context) |
| --- | --- | --- |
| Who supplies it | the app, or a plugin wrapping the provider | the provider |
| Who calls it | the provider, inside `onSuccessCb` | payment handlers |
| Second parameter | `cart` — what was bought | `query` — where to send the shopper |

They never meet: the provider's `onSuccessCb` receives `query` and passes `cart`. Both docblocks now
say which is which, since the two are easy to confuse by name alone.

## Compatibility

Purely additive — the parameter is optional and every existing caller
(`magento-payment-braintree`, `-paypal`, `-afterpay`, `-klarna`, `-multisafepay`,
`mollie-magento-payment`) keeps compiling and behaving identically. No change to the provider prop.

Changeset: `patch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
