### PR TITLE
fix(magento-cart): stable identities for cart clear and cart lock hooks

### DIFF
--- a/.changeset/stable-cart-hook-identities.md
+++ b/.changeset/stable-cart-hook-identities.md
@@ -1,0 +1,8 @@
+---
+'@graphcommerce/magento-cart': patch
+'@graphcommerce/magento-cart-payment-method': patch
+---
+
+Give `useClearCurrentCartId()` and `useCartLock()`'s `lock`/`unlock` a stable function identity, so consumers can list them in a `useEffect` dependency array without the effect re-running on every render.
+
+`useClearCurrentCartId` returned a bare arrow function and `useCartLock` defined `lock`/`unlock` inline, while the neighbouring `useAssignCurrentCartId` already returned a `useCallback`. `useClearCurrentCartId` now uses `useCallback` with the Apollo `cache` as its only dependency (matching `useAssignCurrentCartId`), and `lock`/`unlock` use `useEventCallback` because they read values that legitimately change (`currentCartId`, the router query state and the Apollo client) — `useEventCallback` keeps the identity stable while always reading the latest values, so no stale closure is introduced.

--- a/packages/magento-cart-payment-method/hooks/useCartLock.ts
+++ b/packages/magento-cart-payment-method/hooks/useCartLock.ts
@@ -1,6 +1,7 @@
 import { useApolloClient } from '@graphcommerce/graphql'
 import { cartLock, useCurrentCartId } from '@graphcommerce/magento-cart'
 import { useUrlQuery } from '@graphcommerce/next-ui'
+import { useEventCallback } from '@mui/material'
 import { useEffect, useState } from 'react'
 
 export type CartLockState = {
@@ -37,7 +38,13 @@ export function useCartLock<E extends CartLockState>() {
     }
   })
 
-  const lock = (params: Omit<E, 'locked' | 'cart_id'>) => {
+  /**
+   * `lock` and `unlock` are wrapped in `useEventCallback` so they keep a stable identity across
+   * renders while still reading the latest `currentCartId`, `queryState` and `client`. This allows
+   * consumers to add them to their `useEffect` dependency arrays without re-running the effect on
+   * every render.
+   */
+  const lock = useEventCallback((params: Omit<E, 'locked' | 'cart_id'>) => {
     if (!currentCartId) return undefined
     justLocked = true
     cartLock(client.cache, true)
@@ -46,13 +53,13 @@ export function useCartLock<E extends CartLockState>() {
       cart_id: currentCartId,
       ...params,
     } as unknown as E)
-  }
+  })
 
-  const unlock = async (params: Omit<E, 'locked' | 'cart_id' | 'method'>) => {
+  const unlock = useEventCallback(async (params: Omit<E, 'locked' | 'cart_id' | 'method'>) => {
     cartLock(client.cache, false)
     await setRouterQuery({ cart_id: null, locked: null, method: null, ...params } as E)
     return queryState
-  }
+  })
 
   const resulting: Omit<E, 'locked'> & { locked: boolean; justLocked: boolean } = {
     ...queryState,

--- a/packages/magento-cart/hooks/useClearCurrentCartId.ts
+++ b/packages/magento-cart/hooks/useClearCurrentCartId.ts
@@ -1,14 +1,15 @@
 import { useApolloClient } from '@graphcommerce/graphql'
 import { cookie } from '@graphcommerce/next-ui'
+import { useCallback } from 'react'
 import { CART_ID_COOKIE } from './useAssignCurrentCartId'
 
 export function useClearCurrentCartId() {
   const { cache } = useApolloClient()
 
-  return () => {
+  return useCallback(() => {
     cache.evict({ fieldName: 'currentCartId' })
     cache.evict({ fieldName: 'customerCart' })
     cache.gc()
     cookie(CART_ID_COOKIE, null)
-  }
+  }, [cache])
 }


### PR DESCRIPTION
_Written by Claude Code:_

## What was unstable

Three cart callbacks got a brand new function identity on every render:

- `useClearCurrentCartId()` (`packages/magento-cart/hooks/useClearCurrentCartId.ts`) returned a bare arrow function.
- `useCartLock()`'s `lock` and `unlock` (`packages/magento-cart-payment-method/hooks/useCartLock.ts`) were defined inline in the hook body.

The direct neighbour `useAssignCurrentCartId()` — same file, same kind of callback — already wraps its return value in `useCallback`, so this was plain inconsistency rather than a deliberate choice.

## Why it affects consumers

The correct way to consume these is to list them in the dependency array of the `useEffect` that calls them. That is also what the codebase already assumes elsewhere: `MSPPaymentHandler` declares `onSuccess` as a dependency precisely because `onSuccessCb` in `PaymentMethodContext` is wrapped in `useEventCallback` and therefore stable. The same handler also lists `unlock` — which, until this PR, made that effect re-run on every single render, kept harmless only by the `called` flag from `useMutation`.

The pattern shows up more explicitly in `magento-payment-braintree`:

- `methods/braintree/PaymentMethodPlaceOrder.tsx` wraps `unlock` in a `useEffectEvent` plus a `handledError` ref purely to shield the effect from `unlock`'s churn.
- `methods/braintree/PaymentMethodOptions.tsx` lists `unlock` in its dependency array, so its unlock effect currently re-evaluates on every render.

Downstream projects hit the same thing and end up adding guards in their payment handlers that would not be needed if these identities were stable.

## The fix, per hook

**`useClearCurrentCartId` → `useCallback` with `[cache]`.** The callback closes over exactly one value, the Apollo `cache` from `useApolloClient()`; `CART_ID_COOKIE` is a module constant and `cookie` is a module import. `[cache]` is therefore complete, and this matches `useAssignCurrentCartId` one file over, which uses the identical dependency list for the identical closure.

**`useCartLock`'s `lock`/`unlock` → `useEventCallback`.** These close over values that genuinely change: `currentCartId` (from `useCurrentCartId()`), `queryState` (the router query, new on every navigation), `setRouterQuery` and `client`. A `useCallback` here would only be stable between navigations, which defeats the purpose, and getting the dependency list wrong would trade re-renders for a stale `currentCartId` — the real risk in this change. `useEventCallback` avoids both: the identity never changes, while the body always runs against the most recently rendered values. That is the established convention in this repo for exactly this situation — `PaymentMethodContext`'s `onSuccessCb`, `useFormGql`'s `onBeforeSubmit`/`onComplete` (see the `@graphcommerce/react-hook-form` changelog entry for #2325, which wrapped them for the same stale-closure reason), `useProductList`'s `handleSubmit`, and many more. `useEffectEvent` was considered but rejected: these functions are returned from a hook and passed into event handlers, not confined to a single effect.

`useEventCallback` preserves the function type exactly (`<Fn extends (...args: any[]) => any>(fn: Fn): Fn`), so the tuple returned by `useCartLock` keeps its existing public type.

## Behaviour check on consumers

I checked every consumer of the three callbacks (`magento-payment-braintree`, `-paypal`, `-klarna`, `-adyen`, `-afterpay`, `magento-payment-multisafepay`, `mollie-magento-payment`, `magento-cart-payment-method` itself, plus the examples). None of them rely on the per-render re-run:

- `MSPPaymentHandler` and `MolliePaymentHandler` gate their effects on lock state and the mutation's `called` flag, so they fire on state changes, not on render churn.
- Braintree's `PaymentMethodOptions` unlock effect is gated on `lockstate.justLocked`/`lockstate.locked`, both of which still change independently; `unlock` is additionally idempotent (`cartLock` no-ops when the flag already matches and `setRouterQuery` returns early when the query is unchanged).
- The remaining call sites (`MSPRestoreLocked`, `MSPPaymentPlaceOrder`, `MolliePlaceOrder`, `PaymentMethodContext`, braintree's `PaymentMethodPlaceOrder`) invoke these from click handlers or form callbacks, where identity is irrelevant.

No consumer changes are included here — the workaround in braintree's `PaymentMethodPlaceOrder` can now be simplified, but that is deliberately left out of this PR to keep the change focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
